### PR TITLE
WIP: Read index of struct entry in inline arrays

### DIFF
--- a/export/wiki/species/attacks.py
+++ b/export/wiki/species/attacks.py
@@ -22,14 +22,14 @@ def _convert_attack(attack: StructProperty):
     d: Dict[str, Any] = attack.as_dict()
 
     v = dict(
-        name=d['AttackName'] or None,
-        interval=d['AttackInterval'],
-        dmg=d['MeleeDamageAmount'],
-        radius=d['MeleeSwingRadius'],
-        stamina=d['StaminaCost'],
+        name=d['AttackName'][0] or None,
+        interval=d['AttackInterval'][0],
+        dmg=d['MeleeDamageAmount'][0],
+        radius=d['MeleeSwingRadius'][0],
+        stamina=d['StaminaCost'][0],
     )
 
-    proj = d['ProjectileClass']
+    proj = d['ProjectileClass'][0]
     if proj:
         v['isProjectile'] = True
 

--- a/export/wiki/species/movement.py
+++ b/export/wiki/species/movement.py
@@ -28,15 +28,16 @@ def _gather_speeds(species: PrimalDinoCharacter, multValue: float) -> Dict[str, 
     # TODO: Include ScaleExtraRunningSpeedModifier and ScaleExtraRunningMultiplier(Min|Max|Speed)
 
     cm: ShooterCharacterMovement = species.CharacterMovement[0]
-    nav_props_struct = cm.get('NavAgentProps', fallback=None)
-    nav_props = nav_props_struct.as_dict() if nav_props_struct else {}
+    nav_props = cm.get('NavAgentProps', fallback=None)
+    if not nav_props:
+        return result
 
     isWaterDino = bool(species.bIsWaterDino[0])
-    canWalk = nav_props.get('bCanWalk', True) and not isWaterDino
-    canCrouch = nav_props.get('bCanCrouch', False) and canWalk
+    canWalk = nav_props.get_property('bCanWalk', fallback=True) and not isWaterDino
+    canCrouch = nav_props.get_property('bCanCrouch', fallback=False) and canWalk
     canRun = canWalk and species.bCanRun[0]
-    canSwim = (nav_props.get('bCanSwim', True) or isWaterDino) and not species.bPreventEnteringWater[0]
-    canFly = nav_props.get('bCanFly', False) or species.bIsFlyerDino[0]
+    canSwim = (nav_props.get_property('bCanSwim', fallback=True) or isWaterDino) and not species.bPreventEnteringWater[0]
+    canFly = nav_props.get_property('bCanFly', fallback=False) or species.bIsFlyerDino[0]
 
     if canWalk:
         result['walk'] = dict(base=mult(cm.MaxWalkSpeed[0]))

--- a/export/wiki/stage_spawn_groups.py
+++ b/export/wiki/stage_spawn_groups.py
@@ -77,15 +77,15 @@ def convert_group_entry(struct):
     d = struct.as_dict()
 
     v = dict()
-    v['name'] = d['AnEntryName']
-    v['weight'] = d['EntryWeight']
-    v['classes'] = d['NPCsToSpawn']
-    v['spawnOffsets'] = d['NPCsSpawnOffsets']
+    v['name'] = d['AnEntryName'][0]
+    v['weight'] = d['EntryWeight'][0]
+    v['classes'] = d['NPCsToSpawn'][0]
+    v['spawnOffsets'] = d['NPCsSpawnOffsets'][0]
 
     # Weights, as confirmed by ZenRowe. It's up to the user to calculate actual chances.
-    v['classWeights'] = d['NPCsToSpawnPercentageChance']
+    v['classWeights'] = d['NPCsToSpawnPercentageChance'][0]
 
-    d_swaps = d['NPCRandomSpawnClassWeights'].values
+    d_swaps = d['NPCRandomSpawnClassWeights'][0].values
     if d_swaps:
         v['classSwaps'] = [convert_single_class_swap(entry.as_dict()) for entry in d_swaps]
 
@@ -96,21 +96,22 @@ def convert_limit_entry(struct):
     d = struct.as_dict()
 
     v = dict()
-    v['class'] = d['NPCClass']
-    v['desiredNumberMult'] = d['MaxPercentageOfDesiredNumToAllow']
+    v['class'] = d['NPCClass'][0]
+    v['desiredNumberMult'] = d['MaxPercentageOfDesiredNumToAllow'][0]
 
     return v
 
 
 def convert_single_class_swap(d):
     v = {
-        'from': d['FromClass'],
-        'exact': d['bExactMatch'],
-        'to': d['ToClasses'],
-        'weights': d['Weights'],
+        'from': d['FromClass'][0],
+        'exact': d['bExactMatch'][0],
+        'to': d['ToClasses'][0],
+        'weights': d['Weights'][0],
     }
 
-    if d['ActiveEvent'] and d['ActiveEvent'].value and d['ActiveEvent'].value.value and d['ActiveEvent'].value.value.value != 'None':
+    if d['ActiveEvent'] and d['ActiveEvent'].value and d[
+            'ActiveEvent'].value.value and d['ActiveEvent'].value.value.value != 'None':
         v['during'] = d['ActiveEvent']
 
     return v
@@ -143,9 +144,9 @@ def segregate_container_additions(pgd: UAsset):
     change_queues: Dict[str, List[Dict[str, Any]]] = dict()
     for add in d.values:
         add = add.as_dict()
-        klass = add['SpawnEntriesContainerClass']
-        entries = add['AdditionalNPCSpawnEntries'].values
-        limits = add['AdditionalNPCSpawnLimits'].values
+        klass = add['SpawnEntriesContainerClass'][0]
+        entries = add['AdditionalNPCSpawnEntries'][0].values
+        limits = add['AdditionalNPCSpawnLimits'][0].values
         if not klass.value.value or (not entries and not limits):
             continue
 

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -788,7 +788,7 @@ class StructProperty(UEBase):
 
     count: int
     values: List[UEBase]
-    _as_dict: Optional[Dict[str, UEBase]] = None
+    _as_dict: Optional[PropDict] = None
 
     def _deserialise(self, size):
         values = []
@@ -855,11 +855,11 @@ class StructProperty(UEBase):
             values.append(value)
             self.field_values['count'] += 1
 
-    def as_dict(self) -> Dict[str, UEBase]:
+    def as_dict(self) -> PropDict:
         return self._as_dict or self._convert_to_dict()
 
-    def get_property(self, name: str, fallback=NO_FALLBACK) -> UEBase:
-        value = self.as_dict()[name]
+    def get_property(self, name: str, index: int = 0, fallback=NO_FALLBACK) -> UEBase:
+        value = self.as_dict()[name][index]
 
         if value is not None:
             return value
@@ -870,13 +870,14 @@ class StructProperty(UEBase):
         raise KeyError(f"Property {name} not found")
 
     def _convert_to_dict(self):
-        result: Dict[str, Optional[UEBase]] = defaultdict(lambda: None)
+        result: PropDict = defaultdict(lambda: defaultdict(lambda: None))
 
         for entry in self.values:
             name = str(entry.name)
+            idx = entry.index
             value = entry.value
 
-            result[name] = value
+            result[name][idx] = value
 
         self._as_dict = result
         return result

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -867,7 +867,7 @@ class StructProperty(UEBase):
         if fallback is not NO_FALLBACK:
             return fallback
 
-        raise KeyError(f"Property {name} not found")
+        raise KeyError(f"Property {name}[{index}] not found")
 
     def _convert_to_dict(self):
         result: PropDict = defaultdict(lambda: defaultdict(lambda: None))

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -656,19 +656,21 @@ class CustomVersion(UEBase):
 
 
 class StructEntry(UEBase):
-    string_format = '{name} = ({type}) {value}'
+    string_format = '{name}[{index}] = ({type}) {value}'
 
     name: str
     name_id: NameIndex
     type: NameIndex
     length: int
+    index: int
     value: UEBase
 
     def _deserialise(self):
         self._newField('name_id', NameIndex(self))
         self._newField('type', '<not yet defined>')
         entryType = NameIndex(self).deserialise()
-        self._newField('length', self.stream.readInt64())
+        self._newField('length', self.stream.readInt32())
+        self._newField('index', self.stream.readUInt32())
 
         self.name_id.link()
         clean_name = str(self.name_id).strip()
@@ -679,7 +681,8 @@ class StructEntry(UEBase):
         self.field_values['type'] = entryType
 
         if dbg_structs > 1:
-            print(f'    StructEntry @ {self.start_offset}: name={self.name}, type={entryType}, length={self.length}')
+            print(f'    StructEntry @ {self.start_offset}: name={self.name}, type={entryType}, ' +
+                  f'length={self.length}, index={self.index}')
 
         # We may know the type of the data to go into this...
         subTypeName = TYPED_ARRAY_CONTENT.get(str(self.name), None)


### PR DESCRIPTION
On `master` fields that are read are: name (8 bytes), type (8 bytes), size (8 bytes). This PR splits the last field into two: size (4 bytes) and array index (4 bytes).

Genesis seems to have introduced the first assets that use inline arrays on structs, causing non-critical read errors on those assets (abnormally high sizes).

_This is required for feature-missions._

> /Game/Genesis/Missions/Escort/MissionType_Escort_Ocean_Dolphin.MissionType_Escort_Ocean_Dolphin_C, export of default properties, field "AttackingDinoSetup"