### PR TITLE
Allows root logger to be configed

### DIFF
--- a/ark/discovery.py
+++ b/ark/discovery.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import *
 
@@ -8,13 +7,13 @@ from config import ConfigFile, get_global_config
 from ue.context import ue_parsing_context
 from ue.loader import AssetLoader, AssetLoadException
 from utils.cachefile import cache_data
+from utils.log import get_logger
 
 __all__ = [
     'initialise_hierarchy',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 def initialise_hierarchy(arkman: ArkSteamManager, config: ConfigFile = get_global_config()):

--- a/ark/overrides.py
+++ b/ark/overrides.py
@@ -7,6 +7,7 @@ from typing import *
 
 import yaml
 from pydantic import BaseModel
+
 from config import OVERRIDE_FILENAME
 
 __all__ = [

--- a/automate/ark.py
+++ b/automate/ark.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import re
 import shutil
-from logging import NullHandler, getLogger
 from os import walk
 from pathlib import Path
 from typing import *
@@ -11,6 +10,7 @@ import requests
 
 from config import ConfigFile, get_global_config
 from ue.loader import AssetLoader, ModNotFound, ModResolver
+from utils.log import get_logger
 from utils.name_convert import uelike_prettify
 
 from .modutils import readACFFile, readModInfo, readModMetaInfo, unpackModFile
@@ -25,8 +25,7 @@ ARK_MAIN_APP_ID = 346110
 
 MODDATA_FILENAME = '_moddata.json'
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 class DownloadError(Exception):

--- a/automate/exporter.py
+++ b/automate/exporter.py
@@ -5,7 +5,6 @@ import re
 from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import dataclass, field
 from io import StringIO
-from logging import NullHandler, getLogger
 from operator import itemgetter
 from pathlib import Path, PurePosixPath
 from typing import *
@@ -17,13 +16,13 @@ from ue.gathering import gather_properties
 from ue.hierarchy import find_sub_classes
 from ue.loader import AssetLoader, AssetLoadException
 from ue.proxy import UEProxyStructure
+from utils.log import get_logger
 
 from .git import GitManager
 from .manifest import MANIFEST_FILENAME, update_manifest
 from .run_sections import should_run_section
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 __all__ = [
     'ExportStage',

--- a/automate/git.py
+++ b/automate/git.py
@@ -1,19 +1,18 @@
 import json
 import os
 import tempfile
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import Callable, Optional
 
 from config import ConfigFile, get_global_config
 from utils.brigit import Git, GitException
+from utils.log import get_logger
 
 __all__ = [
     'GitManager',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 MESSAGE_HEADER = "Raptor Claus just dropped some files off"
 

--- a/automate/jsonutils.py
+++ b/automate/jsonutils.py
@@ -1,9 +1,10 @@
 import hashlib
 import json
 import re
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import *
+
+from utils.log import get_logger
 
 __all__ = [
     'save_json_if_changed',
@@ -11,8 +12,7 @@ __all__ = [
     'should_save_json',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 def save_json_if_changed(values: Dict[str, Any], fullpath: Path, pretty: bool) -> Optional[str]:

--- a/automate/manifest.py
+++ b/automate/manifest.py
@@ -1,10 +1,11 @@
 import json
 import re
 from dataclasses import dataclass, field
-from logging import NullHandler, getLogger
 from operator import itemgetter
 from pathlib import Path, PurePosixPath
 from typing import *
+
+from utils.log import get_logger
 
 MANIFEST_FILENAME = '_manifest.json'
 SHRINK_MOD_REGEX = r"{\n\s+(.+: .*),\n\s+(.+: .*),\n\s+(.+: .*)\n\s+}"
@@ -14,8 +15,7 @@ __all__ = [
     'MANIFEST_FILENAME',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 def update_manifest(path: Path) -> Optional[Dict[str, Any]]:

--- a/automate/modutils.py
+++ b/automate/modutils.py
@@ -1,8 +1,8 @@
 import zlib
-from logging import NullHandler, getLogger
 from typing import *
 
 from ue.stream import MemoryStream
+from utils.log import get_logger
 
 __all__ = (
     'DecompressionError',
@@ -14,8 +14,7 @@ __all__ = (
     'loadFileAsStream',
 )
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 class DecompressionError(Exception):

--- a/automate/notification.py
+++ b/automate/notification.py
@@ -1,15 +1,14 @@
 import json
 import os.path
-from logging import NullHandler, getLogger
 from traceback import format_exc
 from typing import List
 
 import requests
 
 from config import ConfigFile, get_global_config
+from utils.log import get_logger
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 __all__ = [
     'handle_exception',

--- a/automate/run.py
+++ b/automate/run.py
@@ -206,6 +206,7 @@ def run(config: ConfigFile):
     except:  # pylint: disable=bare-except
         handle_exception(logfile='logs/errors.log', config=config)
         logger.exception('Caught exception during automation run. Aborting.')
+        exit(1)
 
 
 def main():

--- a/automate/run.py
+++ b/automate/run.py
@@ -12,6 +12,7 @@ import ark.discovery
 from config import LOGGING_FILENAME, ConfigFile, get_global_config
 from export.asb.root import ASBRoot
 from export.wiki.root import WikiRoot
+from utils.log import get_logger
 
 from .ark import ArkSteamManager
 from .exporter import ExportManager
@@ -21,8 +22,7 @@ from .run_sections import parse_runlist, should_run_section
 
 # pylint: enable=invalid-name
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
-logger.addHandler(logging.NullHandler())
+logger = get_logger(__name__)
 
 ROOT_TYPES = [
     ASBRoot,

--- a/automate/stagehelper.py
+++ b/automate/stagehelper.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from logging import NullHandler, getLogger
 from pathlib import Path, PurePosixPath
 from typing import *
 
@@ -8,13 +7,13 @@ from automate.jsonutils import save_as_json, should_save_json
 from config import ConfigFile
 from ue.loader import AssetLoader
 from utils import throw
+from utils.log import get_logger
 
 # __all__ = [
 #     'StageHelper',
 # ]
 
-# logger = getLogger(__name__)
-# logger.addHandler(NullHandler())
+# logger = get_logger(__name__)
 
 # class StageHelper(ExportStage, ABC):
 #     '''

--- a/automate/steamapi.py
+++ b/automate/steamapi.py
@@ -1,10 +1,10 @@
-from logging import NullHandler, getLogger
 from typing import *
 
 import requests
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+from utils.log import get_logger
+
+logger = get_logger(__name__)
 
 
 class SteamApiException(Exception):

--- a/automate/steamcmd.py
+++ b/automate/steamcmd.py
@@ -5,11 +5,11 @@ import os
 import platform
 import subprocess
 import urllib.request
-from logging import NullHandler, getLogger
 from pathlib import Path
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+from utils.log import get_logger
+
+logger = get_logger(__name__)
 
 STCMD_SUCCESS = (0, 6, 7)  # SteamCMD Success return code
 STCMD_TIMEOUT = 10  # SteamCMD Timeout return code

--- a/config.py
+++ b/config.py
@@ -10,12 +10,14 @@ __all__ = [
     'OVERRIDE_FILENAME',
     'LOGGING_FILENAME',
     'HIERARCHY_FILENAME',
+    'ROOT_LOGGER',
 ]
 
 CONFIG_FILENAME = 'config/config.ini'
 OVERRIDE_FILENAME = 'config/overrides.yaml'
 LOGGING_FILENAME = 'config/logging.yaml'
 HIERARCHY_FILENAME = 'config/hierarchy.yaml'
+ROOT_LOGGER = ''
 
 config: Optional[ConfigFile] = None
 

--- a/export/asb/breeding.py
+++ b/export/asb/breeding.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from typing import Any, Dict
 
 import ue.gathering
@@ -6,13 +5,13 @@ from ark.types import PrimalDinoCharacter, PrimalItem
 from ue.loader import AssetLoader
 from ue.utils import clean_double as cd
 from ue.utils import clean_float as cf
+from utils.log import get_logger
 
 __all__ = [
     'gather_breeding_data',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 def gather_breeding_data(char_props: PrimalDinoCharacter, loader: AssetLoader) -> Dict[str, Any]:

--- a/export/asb/colors.py
+++ b/export/asb/colors.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import ue.gathering
@@ -7,14 +6,14 @@ from ark.types import PrimalColorSet, PrimalDinoCharacter, PrimalGameData, Prima
 from ue.asset import UAsset
 from ue.loader import AssetLoader
 from ue.properties import UEBase
+from utils.log import get_logger
 
 __all__ = [
     'gather_pgd_colors',
     'gather_color_data',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 NUM_REGIONS = 6
 NULLABLE_REGION_COLORS = set(['Red'])

--- a/export/asb/export_asb_values.py
+++ b/export/asb/export_asb_values.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import ark.gathering
@@ -16,6 +15,7 @@ from ue.asset import UAsset
 from ue.loader import AssetNotFound, ModNotFound
 from ue.utils import clean_double as cd
 from ue.utils import clean_float as cf
+from utils.log import get_logger
 
 __all__ = [
     'values_from_pgd',
@@ -24,8 +24,7 @@ __all__ = [
 
 DCSC_DEFAULTS: PrimalDinoStatusComponent = PrimalDinoStatusComponent()
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 #                    Ark
 # Health              0

--- a/export/asb/stage_species.py
+++ b/export/asb/stage_species.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from pathlib import PurePosixPath
 from typing import Any, Dict, Optional, cast
 
@@ -6,6 +5,7 @@ from ark.types import COREMEDIA_PGD_PKG, PrimalDinoCharacter
 from automate.hierarchy_exporter import JsonHierarchyExportStage
 from ue.loader import AssetLoadException
 from ue.proxy import UEProxyStructure
+from utils.log import get_logger
 
 from .export_asb_values import values_for_species, values_from_pgd
 
@@ -13,8 +13,7 @@ __all__ = [
     'SpeciesStage',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 class SpeciesStage(JsonHierarchyExportStage):

--- a/export/wiki/items/egg.py
+++ b/export/wiki/items/egg.py
@@ -1,11 +1,10 @@
-from logging import NullHandler, getLogger
 from typing import Any, Dict
 
 from ark.types import PrimalItem
 from ue.loader import AssetLoadException
+from utils.log import get_logger
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 def gather_mic_parameters(d):

--- a/export/wiki/maps/discovery.py
+++ b/export/wiki/maps/discovery.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from typing import Iterable, Iterator
 
 import ue.hierarchy
@@ -7,9 +6,9 @@ from config import ConfigFile, get_global_config
 from export.wiki.consts import LEVEL_SCRIPT_ACTOR_CLS, WORLD_CLS
 from ue.asset import UAsset
 from ue.loader import AssetLoader, AssetLoadException
+from utils.log import get_logger
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 class LevelDiscoverer:

--- a/export/wiki/stage_drops.py
+++ b/export/wiki/stage_drops.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from pathlib import PurePosixPath
 from typing import *
 
@@ -8,6 +7,7 @@ from export.wiki.types import PrimalStructureItemContainer_SupplyCrate
 from ue.hierarchy import find_parent_classes
 from ue.properties import ArrayProperty
 from ue.proxy import UEProxyStructure
+from utils.log import get_logger
 
 __all__ = [
     'DropsStage',
@@ -18,8 +18,9 @@ __all__ = [
     'decode_item_set',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+
+
+logger = get_logger(__name__)
 
 
 class DinoDropInventoryComponent(

--- a/export/wiki/stage_engrams.py
+++ b/export/wiki/stage_engrams.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from pathlib import PurePosixPath
 from typing import *
 
@@ -6,13 +5,15 @@ from automate.hierarchy_exporter import JsonHierarchyExportStage
 from export.wiki.types import PrimalEngramEntry
 from ue.asset import UAsset
 from ue.proxy import UEProxyStructure
+from utils.log import get_logger
 
 __all__ = [
     'EngramsStage',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+
+
+logger = get_logger(__name__)
 
 
 class EngramsStage(JsonHierarchyExportStage):

--- a/export/wiki/stage_items.py
+++ b/export/wiki/stage_items.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from pathlib import PurePosixPath
 from typing import *
 
@@ -6,6 +5,7 @@ from ark.types import PrimalItem
 from automate.hierarchy_exporter import JsonHierarchyExportStage
 from ue.asset import UAsset
 from ue.proxy import UEProxyStructure
+from utils.log import get_logger
 
 from .items.cooking import convert_cooking_values
 from .items.crafting import convert_crafting_values
@@ -17,8 +17,8 @@ __all__ = [
     'ItemsStage',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+
+logger = get_logger(__name__)
 
 
 class ItemsStage(JsonHierarchyExportStage):

--- a/export/wiki/stage_loot_crates.py
+++ b/export/wiki/stage_loot_crates.py
@@ -1,10 +1,10 @@
-from logging import NullHandler, getLogger
 from pathlib import PurePosixPath
 from typing import *
 
 from automate.hierarchy_exporter import JsonHierarchyExportStage
 from export.wiki.types import PrimalStructureItemContainer_SupplyCrate
 from ue.proxy import UEProxyStructure
+from utils.log import get_logger
 
 from .stage_drops import _get_item_sets_override, decode_item_set, get_loot_sets
 
@@ -12,8 +12,8 @@ __all__ = [
     'LootCratesStage',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+
+logger = get_logger(__name__)
 
 
 class LootCratesStage(JsonHierarchyExportStage):

--- a/export/wiki/stage_maps.py
+++ b/export/wiki/stage_maps.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from pathlib import Path, PurePosixPath
 from types import GeneratorType
 from typing import Any, Dict, Iterable, List, Optional, Set
@@ -9,14 +8,14 @@ from automate.jsonutils import save_json_if_changed
 from automate.version import createExportVersion
 from ue.gathering import gather_properties
 from ue.utils import get_assetpath_from_assetname, get_leaf_from_assetname, sanitise_output
+from utils.log import get_logger
 
 from .maps.data_container import MapInfo
 from .maps.discovery import LevelDiscoverer
 from .maps.gathering import EXPORTS, find_gatherer_by_category_name, find_gatherer_for_export
 from .maps.geo import GeoCoordCalculator
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 __all__ = [
     'MapStage',

--- a/export/wiki/stage_species.py
+++ b/export/wiki/stage_species.py
@@ -1,4 +1,3 @@
-from logging import NullHandler, getLogger
 from pathlib import PurePosixPath
 from typing import *
 from typing import cast
@@ -12,6 +11,7 @@ from ue.asset import UAsset
 from ue.gathering import gather_properties
 from ue.proxy import UEProxyStructure
 from ue.utils import clean_double as cd
+from utils.log import get_logger
 
 from .species.attacks import gather_attack_data
 from .species.movement import gather_movement_data
@@ -20,8 +20,8 @@ __all__ = [
     'SpeciesStage',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+
+logger = get_logger(__name__)
 
 OUTPUT_FLAGS = (
     'bAllowCarryFlyerDinos',

--- a/export/wiki/stage_trades.py
+++ b/export/wiki/stage_trades.py
@@ -1,16 +1,17 @@
-from logging import NullHandler, getLogger
 from typing import Any, Dict, cast
 
 from automate.hierarchy_exporter import JsonHierarchyExportStage
 from export.wiki.types import HexagonTradableOption
 from ue.proxy import UEProxyStructure
+from utils.log import get_logger
 
 __all__ = [
     'TradesStage',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+
+
+logger = get_logger(__name__)
 
 
 class TradesStage(JsonHierarchyExportStage):

--- a/interactive/setup.py
+++ b/interactive/setup.py
@@ -1,6 +1,6 @@
 from interactive_utils import *  # pylint: disable=wrong-import-order
 
-from logging import INFO, NullHandler, basicConfig, getLogger
+from logging import INFO, basicConfig
 from pathlib import Path
 from typing import *
 
@@ -12,14 +12,14 @@ from ue.asset import ExportTableItem, ImportTableItem, UAsset
 from ue.gathering import gather_properties
 from ue.hierarchy import find_parent_classes, find_sub_classes, inherits_from
 from ue.loader import AssetLoader, AssetNotFound
+from utils.log import get_logger
 
 is_interactive = bool(getattr(sys, 'ps1', sys.flags.interactive))
 
 if is_interactive:
     basicConfig(level=INFO)
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 config = get_global_config()
 config.settings.SkipInstall = True

--- a/processing/stage_base.py
+++ b/processing/stage_base.py
@@ -1,13 +1,12 @@
 import json
 from abc import ABCMeta
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import Any
 
 from automate.exporter import ExportManager, ExportRoot, ExportStage
+from utils.log import get_logger
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 __all__ = [
     'ProcessingStage',

--- a/processing/stage_biome_maps.py
+++ b/processing/stage_biome_maps.py
@@ -1,15 +1,14 @@
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import List, Optional
 
 from ark.overrides import get_overrides_for_map
 from processing.common import SVGBoundaries
+from utils.log import get_logger
 
 from .region_maps.svg import generate_svg_map
 from .stage_base import ProcessingStage
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 __all__ = [
     'ProcessBiomeMapsStage',

--- a/processing/stage_spawn_maps.py
+++ b/processing/stage_spawn_maps.py
@@ -1,11 +1,11 @@
 import shutil
 from collections import namedtuple
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ark.overrides import get_overrides_for_map
 from processing.common import SVGBoundaries, remove_unicode_control_chars
+from utils.log import get_logger
 
 from .spawn_maps.game_mod import merge_game_mod_groups
 from .spawn_maps.species import calculate_blueprint_freqs, determine_tamability, generate_dino_mappings
@@ -14,8 +14,7 @@ from .spawn_maps.swaps import apply_ideal_global_swaps, apply_ideal_grouplevel_s
     copy_spawn_groups, fix_up_groups, inflate_swap_rules, make_random_class_weights_dict
 from .stage_base import ProcessingStage
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 __all__ = [
     'ProcessSpawnMapsStage',

--- a/ue/asset.py
+++ b/ue/asset.py
@@ -1,7 +1,8 @@
 import weakref
 from collections import namedtuple
-from logging import NullHandler, getLogger
 from typing import *
+
+from utils.log import get_logger
 
 from .base import UEBase
 from .context import INCLUDE_METADATA, get_ctx
@@ -27,8 +28,7 @@ __all__ = [
     'ExportTableItem',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 
 class UAsset(UEBase):

--- a/ue/context.py
+++ b/ue/context.py
@@ -15,9 +15,9 @@ from collections import namedtuple
 from contextlib import ContextDecorator
 from dataclasses import dataclass
 from enum import IntEnum, auto
-from logging import NullHandler, getLogger
 from typing import NamedTuple, Optional, cast
 
+from utils.log import get_logger
 from utils.xlocal import xlocal
 
 __all__ = [
@@ -26,8 +26,7 @@ __all__ = [
     'get_ctx',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 INCLUDE_METADATA = True
 

--- a/ue/hierarchy.py
+++ b/ue/hierarchy.py
@@ -1,5 +1,4 @@
 from functools import lru_cache
-from logging import NullHandler, getLogger
 from operator import attrgetter
 from pathlib import Path
 from typing import *
@@ -11,6 +10,7 @@ from ue.asset import ExportTableItem, ImportTableItem, UAsset
 from ue.context import ue_parsing_context
 from ue.loader import AssetLoader, AssetLoadException
 from ue.tree import get_parent_fullname
+from utils.log import get_logger
 from utils.tree import IndexedTree, Node
 
 from .consts import BLUEPRINT_GENERATED_CLASS_CLS
@@ -29,8 +29,7 @@ __all__ = [
     'iterate_all',
 ]
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 ROOT_NAME = '/Script/CoreUObject.Object'
 

--- a/ue/loader.py
+++ b/ue/loader.py
@@ -5,11 +5,12 @@ import weakref
 from abc import ABC, abstractmethod
 from configparser import ConfigParser
 from itertools import islice
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import *
 
 import psutil  # type: ignore
+
+from utils.log import get_logger
 
 from .asset import ExportTableItem, ImportTableItem, UAsset
 from .base import UEBase
@@ -17,8 +18,7 @@ from .context import ParsingContext, get_ctx
 from .properties import ObjectIndex, ObjectProperty, Property
 from .stream import MemoryStream
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 __all__ = (
     'AssetLoadException',

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -6,9 +6,10 @@ import uuid
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from logging import NullHandler, getLogger
 from numbers import Real
 from typing import *
+
+from utils.log import get_logger
 
 from .base import UEBase
 from .context import INCLUDE_METADATA, get_ctx
@@ -30,8 +31,7 @@ else:
 
 dbg_structs = 0
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 PropDict = Dict[str, Dict[int, UEBase]]
 

--- a/uegrep.py
+++ b/uegrep.py
@@ -1,20 +1,19 @@
 import argparse
 import re
-from logging import WARNING, NullHandler, basicConfig, getLogger
 from pathlib import Path
 from typing import *
 
 from ark.discovery import initialise_hierarchy
 from automate.ark import ArkSteamManager
-from config import ConfigFile, get_global_config
+from config import ROOT_LOGGER, ConfigFile, get_global_config
 from ue.asset import ExportTableItem, ImportTableItem, UAsset
 from ue.hierarchy import find_parent_classes, find_sub_classes, iterate_all
 from ue.loader import AssetLoader, AssetNotFound
+from utils.log import get_logger
 
 # pylint: enable=invalid-name
 
-logger = getLogger(__name__)  # pylint: disable=invalid-name
-logger.addHandler(NullHandler())
+logger = get_logger(__name__)
 
 EPILOG = '''example: python uegrep.py Dodo_Character_C'''
 

--- a/utils/cachefile.py
+++ b/utils/cachefile.py
@@ -7,12 +7,12 @@ import json
 import pickle
 import tempfile
 from collections.abc import Hashable
-from logging import NullHandler, getLogger
 from pathlib import Path
 from typing import *
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+from utils.log import get_logger
+
+logger = get_logger(__name__)
 
 
 def cache_data(key: object, filename: str, generator_fn: Callable[[object], object], force_regenerate=False):

--- a/utils/log.py
+++ b/utils/log.py
@@ -1,9 +1,13 @@
 import os
 import zlib
+from logging import NullHandler, getLogger
 from logging.handlers import RotatingFileHandler
+
+from config import ROOT_LOGGER
 
 __all__ = [
     'CompressedRotatingFileHandler',
+    'get_logger',
 ]
 
 
@@ -35,3 +39,10 @@ def rotator_gz(source: str, dest: str):
             df.write(data)
 
     os.remove(source)
+
+
+def get_logger(name):
+    logger = getLogger(ROOT_LOGGER + name)  # pylint: disable=invalid-name
+    logger.addHandler(NullHandler())
+
+    return logger


### PR DESCRIPTION
[Celery has some special formatters](https://docs.celeryproject.org/en/latest/userguide/tasks.html#logging) that inject the task id into the log so you can easily parse the log to look for the logs for a specific task run you are looking for. As a result, I need to be able to make all loggers in Purlovia inherit from `celery.task`. 

This will allow me to override the loggers without changing the default behavior if Purlovia is ran as a standalone. 

![image](https://user-images.githubusercontent.com/490848/79083781-46d31f00-7cfe-11ea-87a2-3ae32cadb38a.png)
