### PR TITLE
Read struct field headers properly to support indexed fields

### DIFF
--- a/ue/properties.py
+++ b/ue/properties.py
@@ -724,19 +724,21 @@ class CustomVersion(UEBase):
 
 
 class StructEntry(UEBase):
-    string_format = '{name} = ({type}) {value}'
+    string_format = '{name}[{index}] = ({type}) {value}'
 
     name: str
     name_id: NameIndex
     type: NameIndex
     length: int
+    index: int
     value: UEBase
 
     def _deserialise(self):
         self._newField('name_id', NameIndex(self))
         self._newField('type', '<not yet defined>')
         entryType = NameIndex(self).deserialise()
-        self._newField('length', self.stream.readInt64())
+        self._newField('length', self.stream.readInt32())
+        self._newField('index', self.stream.readUInt32())
 
         self.name_id.link()
         clean_name = str(self.name_id).strip()
@@ -747,7 +749,8 @@ class StructEntry(UEBase):
         self.field_values['type'] = entryType
 
         if dbg_structs > 1:
-            print(f'    StructEntry @ {self.start_offset}: name={self.name}, type={entryType}, length={self.length}')
+            print(f'    StructEntry @ {self.start_offset}: name={self.name}, type={entryType}, ' +
+                  f'length={self.length}, index={self.index}')
 
         # We may know the type of the data to go into this...
         subTypeName = TYPED_ARRAY_CONTENT.get(str(self.name), None)

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -964,7 +964,12 @@ class StructProperty(UEBase):
         if self.count == 0:
             return self.values
 
-        return self.as_dict()
+        # Pull all props into `out[name][index] = value` format
+        out = self.as_dict()
+
+        # Reduce any prop with just index 0 to only its value
+        out = {k: v[0] if list(v.keys()) == [0] else v for k, v in out.items()}
+        return out
 
     if INCLUDE_METADATA and support_pretty:
 

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -857,7 +857,7 @@ class StructProperty(UEBase):
 
     count: int
     values: List[UEBase]
-    _as_dict: Optional[Dict[str, UEBase]] = None
+    _as_dict: Optional[PropDict] = None
 
     def _deserialise(self, size):
         values = []
@@ -927,11 +927,11 @@ class StructProperty(UEBase):
             values.append(value)
             self.field_values['count'] += 1
 
-    def as_dict(self) -> Dict[str, UEBase]:
+    def as_dict(self) -> PropDict:
         return self._as_dict or self._convert_to_dict()
 
-    def get_property(self, name: str, fallback=NO_FALLBACK) -> UEBase:
-        value = self.as_dict()[name]
+    def get_property(self, name: str, index: int = 0, fallback=NO_FALLBACK) -> UEBase:
+        value = self.as_dict()[name][index]
 
         if value is not None:
             return value
@@ -942,13 +942,14 @@ class StructProperty(UEBase):
         raise KeyError(f"Property {name} not found")
 
     def _convert_to_dict(self):
-        result: Dict[str, Optional[UEBase]] = defaultdict(lambda: None)
+        result: PropDict = defaultdict(lambda: defaultdict(lambda: None))
 
         for entry in self.values:
             name = str(entry.name)
             if hasattr(entry, 'value'):
+                idx = entry.index
                 value = entry.value
-                result[name] = value
+                result[name][idx] = value
 
         self._as_dict = result
         return result


### PR DESCRIPTION
This way we can properly support structs with an array whose number of elements cannot be changed (i.e. is a simple C++ array and not a TArray; indices must be valid enum members for UE metadata to be generated).

Example asset:
/Game/Genesis/Missions/Hunt/Bog/MissionType_Hunt_Sarco
(class default object export, DinosToSpawn property, any element, fields: BasePointsPerStat, PlayerAddedPointsPerStat)

- [x] Split the 64-bit size field into two 32-bit fields: array index & size.
- [ ] Update existing code dependent on old StructProperty.as_dict() signature