### PR TITLE
Upgrade items onto models

### DIFF
--- a/ark/types.py
+++ b/ark/types.py
@@ -284,7 +284,7 @@ class PrimalItem(UEProxyStructure, uetype=PRIMAL_ITEM_CLS):
     bIsEgg = uebools(False)
     bIsItemSkin = uebools(False)
     bSupportDragOntoOtherItem = uebools(False)
-    bUseItemDurability = uebools(True)
+    bUseItemDurability = uebools(False)
     bOverrideRepairingRequirements = uebools(False)
     bIsCookingIngredient = uebools(False)
     bPreventCheatGive = uebools(False)
@@ -324,6 +324,7 @@ class PrimalItem(UEProxyStructure, uetype=PRIMAL_ITEM_CLS):
     Ingredient_FoodIncreasePerQuantity = uefloats(0.1)
     Ingredient_HealthIncreasePerQuantity = uefloats(0.1)
     Ingredient_StaminaIncreasePerQuantity = uefloats(0.1)
+    Ingredient_WaterIncreasePerQuantity = uefloats(0.1)
 
     BaseCraftingResourceRequirements: Mapping[int, ArrayProperty]  # = []
     ItemIconMaterialParent: Mapping[int, ObjectProperty]  # = 'None'

--- a/ark/types.py
+++ b/ark/types.py
@@ -289,6 +289,7 @@ class PrimalItem(UEProxyStructure, uetype=PRIMAL_ITEM_CLS):
     bIsCookingIngredient = uebools(False)
     bPreventCheatGive = uebools(False)
     bAllowRepair = uebools(True)
+    bUseItemStats = uebools(False)
     bDurabilityRequirementIgnoredInWater = uebools(False)
     bUseBPGetItemName = uebools(False)
     BaseCraftingXP = uefloats(2.0)

--- a/automate/jsonutils.py
+++ b/automate/jsonutils.py
@@ -131,6 +131,10 @@ JOIN_LINE_FIELDS = (
     'base|crouch|sprint',
     'min|max',
     'min|max|pow',
+    'qty|type',
+    'exact|qty|type',
+    'stat|value|useItemQuality',
+    'stat|value|useItemQuality|duration',
 )
 
 

--- a/export/wiki/items/cooking.py
+++ b/export/wiki/items/cooking.py
@@ -1,12 +1,23 @@
-from typing import Any, Dict
+from typing import Optional
 
 from ark.types import PrimalItem
+from automate.hierarchy_exporter import ExportModel, Field
+from ue.properties import FloatProperty
 
 
-def convert_cooking_values(item: PrimalItem) -> Dict[str, Any]:
-    return dict(cookingStats=dict(
+class CookingIngredientData(ExportModel):
+    health: Optional[FloatProperty] = Field(..., title="Health increased per item")
+    stamina: Optional[FloatProperty] = Field(..., title="Stamina increased per item")
+    food: Optional[FloatProperty] = Field(..., title="Food increased per item")
+    weight: Optional[FloatProperty] = Field(..., title="Weight increased per item")
+    water: Optional[FloatProperty] = Field(..., title="Water increased per item in a drink")
+
+
+def convert_cooking_values(item: PrimalItem) -> CookingIngredientData:
+    return CookingIngredientData(
         health=item.Ingredient_HealthIncreasePerQuantity[0],
         stamina=item.Ingredient_StaminaIncreasePerQuantity[0],
         food=item.Ingredient_FoodIncreasePerQuantity[0],
         weight=item.Ingredient_WeightIncreasePerQuantity[0],
-    ))
+        water=item.Ingredient_WaterIncreasePerQuantity[0],
+    )

--- a/export/wiki/items/cooking.py
+++ b/export/wiki/items/cooking.py
@@ -1,20 +1,22 @@
 from ark.types import PrimalItem
 from automate.hierarchy_exporter import ExportModel, Field
 
+from export.wiki.models import FloatLike
+
 
 class CookingIngredientData(ExportModel):
-    health: float = Field(0, title="Health increased per item")
-    stamina: float = Field(0, title="Stamina increased per item")
-    food: float = Field(0, title="Food increased per item")
-    weight: float = Field(0, title="Weight increased per item")
-    water: float = Field(0, title="Water increased per item in a drink")
+    health: FloatLike = Field(0, description="Health increased per item")
+    stamina: FloatLike = Field(0, description="Stamina increased per item")
+    food: FloatLike = Field(0, description="Food increased per item")
+    weight: FloatLike = Field(0, description="Weight increased per item")
+    water: FloatLike = Field(0, description="Water increased per item in a drink")
 
 
 def convert_cooking_values(item: PrimalItem) -> CookingIngredientData:
     return CookingIngredientData(
-        health=float(item.Ingredient_HealthIncreasePerQuantity[0]),
-        stamina=float(item.Ingredient_StaminaIncreasePerQuantity[0]),
-        food=float(item.Ingredient_FoodIncreasePerQuantity[0]),
-        weight=float(item.Ingredient_WeightIncreasePerQuantity[0]),
-        water=float(item.Ingredient_WaterIncreasePerQuantity[0]),
+        health=item.Ingredient_HealthIncreasePerQuantity[0],
+        stamina=item.Ingredient_StaminaIncreasePerQuantity[0],
+        food=item.Ingredient_FoodIncreasePerQuantity[0],
+        weight=item.Ingredient_WeightIncreasePerQuantity[0],
+        water=item.Ingredient_WaterIncreasePerQuantity[0],
     )

--- a/export/wiki/items/cooking.py
+++ b/export/wiki/items/cooking.py
@@ -1,23 +1,20 @@
-from typing import Optional
-
 from ark.types import PrimalItem
 from automate.hierarchy_exporter import ExportModel, Field
-from ue.properties import FloatProperty
 
 
 class CookingIngredientData(ExportModel):
-    health: Optional[FloatProperty] = Field(..., title="Health increased per item")
-    stamina: Optional[FloatProperty] = Field(..., title="Stamina increased per item")
-    food: Optional[FloatProperty] = Field(..., title="Food increased per item")
-    weight: Optional[FloatProperty] = Field(..., title="Weight increased per item")
-    water: Optional[FloatProperty] = Field(..., title="Water increased per item in a drink")
+    health: float = Field(0, title="Health increased per item")
+    stamina: float = Field(0, title="Stamina increased per item")
+    food: float = Field(0, title="Food increased per item")
+    weight: float = Field(0, title="Weight increased per item")
+    water: float = Field(0, title="Water increased per item in a drink")
 
 
 def convert_cooking_values(item: PrimalItem) -> CookingIngredientData:
     return CookingIngredientData(
-        health=item.Ingredient_HealthIncreasePerQuantity[0],
-        stamina=item.Ingredient_StaminaIncreasePerQuantity[0],
-        food=item.Ingredient_FoodIncreasePerQuantity[0],
-        weight=item.Ingredient_WeightIncreasePerQuantity[0],
-        water=item.Ingredient_WaterIncreasePerQuantity[0],
+        health=float(item.Ingredient_HealthIncreasePerQuantity[0]),
+        stamina=float(item.Ingredient_StaminaIncreasePerQuantity[0]),
+        food=float(item.Ingredient_FoodIncreasePerQuantity[0]),
+        weight=float(item.Ingredient_WeightIncreasePerQuantity[0]),
+        water=float(item.Ingredient_WaterIncreasePerQuantity[0]),
     )

--- a/export/wiki/items/crafting.py
+++ b/export/wiki/items/crafting.py
@@ -1,46 +1,80 @@
-from typing import Any, Dict, Union
+from typing import List, Optional, Tuple, Union
 
 from ark.types import PrimalItem
-from ue.properties import IntProperty
+from automate.hierarchy_exporter import ExportModel, Field
+from ue.properties import FloatProperty, IntProperty
 
 
-def convert_recipe_entry(entry):
+class RecipeIngredient(ExportModel):
+    exact: Optional[bool] = Field(..., title="Are child classes accepted?")
+    qty: Optional[FloatProperty] = Field(
+        ...,
+        title="Required quantity",
+        description="Scales with blueprint quality",
+    )
+    type: Optional[str] = Field(..., title="Item blueprint")
+
+
+class CraftingData(ExportModel):
+    xp: Optional[FloatProperty] = Field(..., title="XP granted per item crafted")
+    bpCraftTime: Optional[FloatProperty] = Field(..., title="Time to craft a blueprint")
+    minLevelReq: Optional[IntProperty] = Field(..., title="Required player level")
+    productCount: int = Field(..., title="Number of products")
+    skillQualityMult: Tuple[FloatProperty,
+                            FloatProperty] = Field(..., title="Min and max multipliers of Crafting Skill's effect on quality")
+    recipe: List[Optional[RecipeIngredient]] = Field(..., title="Required ingredients")
+
+
+class RepairData(ExportModel):
+    xp: Optional[FloatProperty] = Field(..., title="XP granted per item repaired")
+    time: Optional[FloatProperty] = Field(..., title="Time to repair an item")
+    resourceMult: Optional[FloatProperty] = Field(..., title="Ingredient count multiplier")
+    recipe: Optional[List[RecipeIngredient]] = Field(None, title="Required ingredients override")
+
+
+def convert_recipe_entry(entry) -> RecipeIngredient:
     type_value = entry['ResourceItemType'].value
     type_value = type_value and type_value.value
     if not type_value:
         return None
 
-    result = dict(
-        exact=entry['bCraftingRequireExactResourceType'],
+    return RecipeIngredient(
+        exact=bool(entry['bCraftingRequireExactResourceType']),
         qty=entry['BaseResourceRequirement'],
-        type=type_value.name,
+        type=str(type_value.name),
     )
-    return result
 
 
-def convert_crafting_values(item: PrimalItem) -> Dict[str, Any]:
+def convert_crafting_values(item: PrimalItem) -> Tuple[Optional[CraftingData], Optional[RepairData]]:
+    recipe = item.get('BaseCraftingResourceRequirements', 0, None)
+    if not recipe:
+        return None, None
+
+    # Crafted item number
     if item.bCraftDontActuallyGiveItem[0]:
         product_count: Union[int, IntProperty] = 0
+    elif item.CraftingGivesItemQuantityOverride[0].value >= 1:
+        product_count = item.CraftingGiveItemCount[0]
     else:
-        if item.CraftingGivesItemQuantityOverride[0].value >= 1:
-            product_count = item.CraftingGiveItemCount[0]
-        else:
-            product_count = item.ItemQuantity[0]
+        product_count = item.ItemQuantity[0]
 
-    v: Dict[str, Any] = dict(crafting=dict(
+    crafting = CraftingData(
         xp=item.BaseCraftingXP[0],
         bpCraftTime=item.BlueprintTimeToCraft[0],
         minLevelReq=item.CraftingMinLevelRequirement[0],
-        productCount=product_count,
+        productCount=int(product_count),
         skillQualityMult=(item.CraftingSkillQualityMultiplierMin[0], item.CraftingSkillQualityMultiplierMax[0]),
-    ))
+        recipe=[convert_recipe_entry(entry.as_dict()) for entry in recipe.values],
+    )
 
-    recipe = item.get('BaseCraftingResourceRequirements', 0, None)
-    if recipe and recipe.values:
-        v['crafting']['recipe'] = [v for v in (convert_recipe_entry(entry.as_dict()) for entry in recipe.values) if v]
+    # Do not export crafting info if recipe consists only of nulls
+    if not all(crafting.recipe):
+        return None, None
 
-    if item.bAllowRepair[0]:
-        v['repair'] = dict(
+    # Durability repair info
+    repair = None
+    if bool(item.bAllowRepair[0]) and bool(item.bUseItemDurability[0]):
+        repair = RepairData(
             xp=item.BaseRepairingXP[0],
             time=item.TimeForFullRepair[0],
             resourceMult=item.RepairResourceRequirementMultiplier[0],
@@ -48,6 +82,6 @@ def convert_crafting_values(item: PrimalItem) -> Dict[str, Any]:
         if item.bOverrideRepairingRequirements[0]:
             recipe = item.get('OverrideRepairingRequirements', 0, None)
             if recipe and recipe.values:
-                v['repair']['recipe'] = [v for v in (convert_recipe_entry(entry.as_dict()) for entry in recipe.values) if v]
+                repair.recipe = [convert_recipe_entry(entry.as_dict()) for entry in recipe.values]
 
-    return v
+    return crafting, repair

--- a/export/wiki/items/durability.py
+++ b/export/wiki/items/durability.py
@@ -13,4 +13,11 @@ def convert_durability_values(item: PrimalItem) -> Optional[float]:
     if not statinfo['bUsed']:
         return None
 
-    return statinfo['InitialValueConstant']
+    # Enough for the base value.
+    out = statinfo['InitialValueConstant']
+
+    maxv = statinfo['AbsoluteMaxValue']
+    if maxv != 0 and out > maxv:
+        out = statinfo['AbsoluteMaxValue']
+
+    return out

--- a/export/wiki/items/durability.py
+++ b/export/wiki/items/durability.py
@@ -1,10 +1,13 @@
-from typing import Any, Dict
+from typing import Optional
 
 from ark.types import PrimalItem
+from automate.hierarchy_exporter import ExportModel, Field
+from ue.properties import FloatProperty
 
 
-def convert_durability_values(item: PrimalItem) -> Dict[str, Any]:
-    return dict(durability=dict(
-        min=item.MinItemDurability[0],
-        ignoreInWater=item.bDurabilityRequirementIgnoredInWater[0],
-    ))
+class DurabilityData(ExportModel):
+    min: Optional[FloatProperty] = Field(..., title="Minimum number of units")
+
+
+def convert_durability_values(item: PrimalItem) -> DurabilityData:
+    return DurabilityData(min=item.MinItemDurability[0], )

--- a/export/wiki/items/durability.py
+++ b/export/wiki/items/durability.py
@@ -1,11 +1,16 @@
+from typing import Optional
+
 from ark.types import PrimalItem
-from automate.hierarchy_exporter import ExportModel, Field
-from ue.properties import FloatProperty
+
+from .poc_stat_gathering import STAT_DURABILITY, gather_item_stat
 
 
-class DurabilityData(ExportModel):
-    min: FloatProperty = Field(..., title="Minimum number of units")
+def convert_durability_values(item: PrimalItem) -> Optional[float]:
+    if not item.bUseItemDurability[0] or not item.bUseItemStats[0]:
+        return None
 
+    statinfo = gather_item_stat(item, STAT_DURABILITY)
+    if not statinfo['bUsed']:
+        return None
 
-def convert_durability_values(item: PrimalItem) -> DurabilityData:
-    return DurabilityData(min=item.MinItemDurability[0], )
+    return statinfo['InitialValueConstant']

--- a/export/wiki/items/durability.py
+++ b/export/wiki/items/durability.py
@@ -2,14 +2,14 @@ from typing import Optional
 
 from ark.types import PrimalItem
 
-from .poc_stat_gathering import STAT_DURABILITY, gather_item_stat
+from .stat_gathering import Stat, gather_item_stat
 
 
 def convert_durability_values(item: PrimalItem) -> Optional[float]:
     if not item.bUseItemDurability[0] or not item.bUseItemStats[0]:
         return None
 
-    statinfo = gather_item_stat(item, STAT_DURABILITY)
+    statinfo = gather_item_stat(item, Stat.Durability)
     if not statinfo['bUsed']:
         return None
 

--- a/export/wiki/items/durability.py
+++ b/export/wiki/items/durability.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 from ark.types import PrimalItem
 from automate.hierarchy_exporter import ExportModel, Field
 from ue.properties import FloatProperty
 
 
 class DurabilityData(ExportModel):
-    min: Optional[FloatProperty] = Field(..., title="Minimum number of units")
+    min: FloatProperty = Field(..., title="Minimum number of units")
 
 
 def convert_durability_values(item: PrimalItem) -> DurabilityData:

--- a/export/wiki/items/egg.py
+++ b/export/wiki/items/egg.py
@@ -9,8 +9,8 @@ logger = get_logger(__name__)
 
 
 class EggData(ExportModel):
-    dinoClass: Optional[str] = Field(..., title="Dino to be spawned")
-    temperature: Optional[Tuple[FloatProperty, FloatProperty]] = Field(False, title="Hatching temperature range")
+    dinoClass: str = Field(..., title="Dino to be spawned")
+    temperature: Tuple[FloatProperty, FloatProperty] = Field(..., title="Hatching temperature range")
 
 
 def convert_egg_values(item: PrimalItem) -> Optional[EggData]:

--- a/export/wiki/items/egg.py
+++ b/export/wiki/items/egg.py
@@ -15,10 +15,10 @@ class EggData(ExportModel):
 
 def convert_egg_values(item: PrimalItem) -> Optional[EggData]:
     dino_class = item.get('EggDinoClassToSpawn', 0, None)
-    if not dino_class:
+    if not dino_class or not dino_class.value or not dino_class.value.value:
         return None
 
     return EggData(
-        dinoClass=str(dino_class),
+        dinoClass=dino_class.value.value.format_for_json(),
         temperature=(item.EggMinTemperature[0], item.EggMaxTemperature[0]),
     )

--- a/export/wiki/items/egg.py
+++ b/export/wiki/items/egg.py
@@ -1,61 +1,24 @@
-from typing import Any, Dict
+from typing import Optional, Tuple
 
 from ark.types import PrimalItem
-from ue.loader import AssetLoadException
+from automate.hierarchy_exporter import ExportModel, Field
+from ue.properties import FloatProperty
 from utils.log import get_logger
 
 logger = get_logger(__name__)
 
 
-def gather_mic_parameters(d):
-    v = dict()
-
-    for param in d.values:
-        param = param.as_dict()
-        v[str(param['ParameterName'])] = param['ParameterValue']
-
-    return v
+class EggData(ExportModel):
+    dinoClass: Optional[str] = Field(..., title="Dino to be spawned")
+    temperature: Optional[Tuple[FloatProperty, FloatProperty]] = Field(False, title="Hatching temperature range")
 
 
-def gather_hud_color_data(mic):
-    v = dict()
-    props = mic.properties.as_dict()
-    d = gather_mic_parameters(props['ScalarParameterValues'][0])
-    d.update(gather_mic_parameters(props['VectorParameterValues'][0]))
-
-    color0 = d.get('Color0', None)
-    color4 = d.get('Color4', None)
-    if color0:
-        v['red'] = dict(
-            intensity=d.get('Color0_RedIntensity', 1.0),
-            color=color0.values[0],
-        )
-    if color4:
-        v['cyan'] = dict(
-            intensity=d.get('Color4_CyanIntensity', 1.0),
-            color=color4.values[0],
-        )
-
-    return v
-
-
-def convert_egg_values(item: PrimalItem) -> Dict[str, Any]:
-    v = dict()
-
+def convert_egg_values(item: PrimalItem) -> Optional[EggData]:
     dino_class = item.get('EggDinoClassToSpawn', 0, None)
-    if dino_class:
-        v['dinoClass'] = dino_class
-        v['temperature'] = (item.EggMinTemperature[0], item.EggMaxTemperature[0])
+    if not dino_class:
+        return None
 
-    hud_mic_ref = item.get('ItemIconMaterialParent', 0, None)
-    if hud_mic_ref and hud_mic_ref.value and hud_mic_ref.value.value:
-        try:
-            hud_mic = item.get_source().asset.loader.load_related(hud_mic_ref)
-            hud_mic = hud_mic.default_export
-            hud_colors = gather_hud_color_data(hud_mic)
-            if hud_colors:
-                v['hudColorisation'] = hud_colors
-        except AssetLoadException:
-            logger.warning(f'Failure while gathering color data from {hud_mic_ref.value.value.fullname}', exc_info=True)
-
-    return v
+    return EggData(
+        dinoClass=str(dino_class),
+        temperature=(item.EggMinTemperature[0], item.EggMaxTemperature[0]),
+    )

--- a/export/wiki/items/egg.py
+++ b/export/wiki/items/egg.py
@@ -1,16 +1,16 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 from ark.types import PrimalItem
 from automate.hierarchy_exporter import ExportModel, Field
-from ue.properties import FloatProperty
+from export.wiki.models import MinMaxRange
 from utils.log import get_logger
 
 logger = get_logger(__name__)
 
 
 class EggData(ExportModel):
-    dinoClass: str = Field(..., title="Dino to be spawned")
-    temperature: Tuple[FloatProperty, FloatProperty] = Field(..., title="Hatching temperature range")
+    dinoClass: str = Field(..., description="Dino to be spawned")
+    temperature: MinMaxRange = Field(..., description="Hatching temperature range")
 
 
 def convert_egg_values(item: PrimalItem) -> Optional[EggData]:
@@ -20,5 +20,5 @@ def convert_egg_values(item: PrimalItem) -> Optional[EggData]:
 
     return EggData(
         dinoClass=dino_class.value.value.format_for_json(),
-        temperature=(item.EggMinTemperature[0], item.EggMaxTemperature[0]),
+        temperature=MinMaxRange(min=item.EggMinTemperature[0], max=item.EggMaxTemperature[0]),
     )

--- a/export/wiki/items/poc_stat_gathering.py
+++ b/export/wiki/items/poc_stat_gathering.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict
+
+from ark.types import PrimalItem
+from ue.asset import ExportTableItem
+from ue.hierarchy import find_parent_classes
+
+DEFAULTS = {
+    # DevKit Verified
+    'bUsed': False,
+    'InitialValueConstant': 0,
+}
+
+STAT_GENERIC_QUALITY = 0
+STAT_ARMOR = 1
+STAT_DURABILITY = 2
+STAT_DAMAGE_PERCENT = 3
+STAT_CLIP_AMMO = 4
+STAT_HYPO_INSULATION = 5
+STAT_WEIGHT = 6
+STAT_HYPER_INSULATION = 7
+
+
+def _gather_props_from_export(export: ExportTableItem, index: int, output: Dict[str, Any]):
+    props = export.properties.get_property('ItemStatInfos', index, fallback=None)
+    if not props:
+        return
+
+    for key, value in props.as_dict().items():
+        output[key] = value
+
+
+def gather_item_stat(item: PrimalItem, index: int) -> Dict[str, Any]:
+    leaf_export = item.get_source()
+    loader = leaf_export.asset.loader
+    output = dict(**DEFAULTS)
+
+    # Make sure this is always the default export, and not e.g. default class.
+    leaf_export = leaf_export.asset.default_export
+
+    for kls in reversed(list(find_parent_classes(leaf_export))):
+
+        if not kls.startswith('/Game'):
+            continue
+
+        asset = loader[kls]
+        super_export = asset.default_export
+
+        _gather_props_from_export(super_export, index, output)
+
+    _gather_props_from_export(leaf_export, index, output)
+
+    return output

--- a/export/wiki/items/poc_stat_gathering.py
+++ b/export/wiki/items/poc_stat_gathering.py
@@ -8,6 +8,9 @@ DEFAULTS = {
     # DevKit Verified
     'bUsed': False,
     'InitialValueConstant': 0,
+    'StateModifierScale': 1,
+    'DefaultModifierValue': 0,
+    'AbsoluteMaxValue': 0,
 }
 
 STAT_GENERIC_QUALITY = 0

--- a/export/wiki/items/stat_gathering.py
+++ b/export/wiki/items/stat_gathering.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Dict
 
 from ark.types import PrimalItem
@@ -13,14 +14,16 @@ DEFAULTS = {
     'AbsoluteMaxValue': 0,
 }
 
-STAT_GENERIC_QUALITY = 0
-STAT_ARMOR = 1
-STAT_DURABILITY = 2
-STAT_DAMAGE_PERCENT = 3
-STAT_CLIP_AMMO = 4
-STAT_HYPO_INSULATION = 5
-STAT_WEIGHT = 6
-STAT_HYPER_INSULATION = 7
+
+class Stat(Enum):
+    GenericQuality = 0
+    Armor = 1
+    Durability = 2
+    DamagePercent = 3
+    ClipAmmo = 4
+    HypoInsulation = 5
+    Weight = 6
+    HyperInsulation = 7
 
 
 def _gather_props_from_export(export: ExportTableItem, index: int, output: Dict[str, Any]):
@@ -32,10 +35,11 @@ def _gather_props_from_export(export: ExportTableItem, index: int, output: Dict[
         output[key] = value
 
 
-def gather_item_stat(item: PrimalItem, index: int) -> Dict[str, Any]:
+def gather_item_stat(item: PrimalItem, index: Stat) -> Dict[str, Any]:
     leaf_export = item.get_source()
     loader = leaf_export.asset.loader
-    output = dict(**DEFAULTS)
+    output = dict(DEFAULTS)
+    ark_index = index.value
 
     # Make sure this is always the default export, and not e.g. default class.
     leaf_export = leaf_export.asset.default_export
@@ -45,11 +49,11 @@ def gather_item_stat(item: PrimalItem, index: int) -> Dict[str, Any]:
         if not kls.startswith('/Game'):
             continue
 
+        # Load the asset and get its default export (the CDO).
+        # find_parent_classes gives us merely a list of parent classes, and not "parent" CDOs.
         asset = loader[kls]
         super_export = asset.default_export
 
-        _gather_props_from_export(super_export, index, output)
-
-    _gather_props_from_export(leaf_export, index, output)
+        _gather_props_from_export(super_export, ark_index, output)
 
     return output

--- a/export/wiki/items/status.py
+++ b/export/wiki/items/status.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from ark.types import PrimalItem
 from automate.hierarchy_exporter import ExportModel, Field
@@ -64,11 +64,7 @@ def convert_status_effect(entry) -> StatEffectData:
 
 
 def convert_status_effects(item: PrimalItem) -> List[StatEffectData]:
-    # TODO: Game bug.
     # Behavior verified 2021/04/26 and 2021/04/28.
-    # Modifiers with bUseItemQuality set to true seem to copy the value of the first modifier
-    # for the same stat.
-    # This is not implemented below and currently requires extra caution when reviewing data.
 
     status_effects = item.UseItemAddCharacterStatusValues[0]
     out = list()
@@ -76,5 +72,13 @@ def convert_status_effects(item: PrimalItem) -> List[StatEffectData]:
     for entry in status_effects.values:
         effect = convert_status_effect(entry)
         out.append(effect)
+
+    # Modifiers with bUseItemQuality set to true seem to copy the value of the first modifier
+    # for the same stat.
+    value_bases: Dict[str, FloatProperty] = dict()
+
+    for effect in out:
+        if effect.useItemQuality:
+            effect.value = value_bases.setdefault(effect.stat, effect.value)
 
     return out

--- a/export/wiki/items/status.py
+++ b/export/wiki/items/status.py
@@ -1,10 +1,35 @@
-def convert_status_effect(entry):
+from typing import Optional, Tuple, Union
+
+from automate.hierarchy_exporter import ExportModel, Field
+from ue.properties import FloatProperty
+
+
+class StatEffectData(ExportModel):
+    value: Optional[FloatProperty] = Field(..., title="")
+    useItemQuality: bool = Field(False, title="")
+    descriptionIndex: Optional[int] = Field(..., title="")
+    pctOf: Optional[str] = Field(None, title="")
+    pctAbsRange: Optional[Tuple[FloatProperty, FloatProperty]] = Field(None, title="")
+    setValue: bool = Field(False, title="")
+    setAddValue: bool = Field(False, title="")
+    forceUseOnDino: bool = Field(False, title="")
+    allowWhenFull: bool = Field(True, title="")
+    qualityMult: float = Field(1.0, title="")
+    duration: Optional[Union[float, FloatProperty]] = Field(0, title="")
+
+
+def convert_status_effect(entry) -> Tuple[str, StatEffectData]:
     d = entry.as_dict()
     stat_name = d['StatusValueType'].get_enum_value_name().lower()
-    result = dict(
+    result = StatEffectData(
         value=d['BaseAmountToAdd'],
-        useItemQuality=d['bUseItemQuality'],
+        useItemQuality=bool(d['bUseItemQuality']),
         descriptionIndex=d['StatusValueModifierDescriptionIndex'],
+        setValue=bool(d['bSetValue']),
+        setAddValue=bool(d['bSetAdditionalValue']),
+        forceUseOnDino=bool(d['bForceUseStatOnDinos']),
+        allowWhenFull=bool(d['bDontRequireLessThanMaxToUse']),
+        qualityMult=float(d['ItemQualityAddValueMultiplier']),
 
         # 'bContinueOnUnchangedValue = (BoolProperty) False',
         # 'bResetExistingModifierDescriptionIndex = (BoolProperty) False',
@@ -17,32 +42,19 @@ def convert_status_effect(entry):
     pctOfMax = d['bPercentOfMaxStatusValue']
     pctOfCur = d['bPercentOfCurrentStatusValue']
     if pctOfCur or pctOfMax:
-        result['pctOf'] = 'max' if pctOfMax else 'current'
-        result['pctAbsRange'] = (d['PercentAbsoluteMinValue'], d['PercentAbsoluteMaxValue'])
-
-    if d['bSetValue']:
-        result['setValue'] = True
-    if d['bSetAdditionalValue']:
-        result['setAddValue'] = True
-    if d['bForceUseStatOnDinos']:
-        result['forceUseOnDino'] = True
-    if not d['bDontRequireLessThanMaxToUse']:
-        result['allowWhenFull'] = False
-
-    qlyMult = d['ItemQualityAddValueMultiplier']
-    if qlyMult != 1.0:
-        result['qualityMult'] = d['ItemQualityAddValueMultiplier']
+        result.pctOf = 'max' if pctOfMax else 'current'
+        result.pctAbsRange = (d['PercentAbsoluteMinValue'], d['PercentAbsoluteMaxValue'])
 
     if d['bAddOverTimeSpeedInSeconds']:
-        result['duration'] = d['AddOverTimeSpeed']
+        result.duration = d['AddOverTimeSpeed']
     else:
         if d['AddOverTimeSpeed'] == 0:
             # Assume instant
-            result['duration'] = 0
+            result.duration = 0
         else:
             # Duration = amount / speed
             duration = abs(d['BaseAmountToAdd']) / d['AddOverTimeSpeed']
             duration = float(format(duration, '.7g'))
-            result['duration'] = duration
+            result.duration = duration
 
     return (stat_name, result)

--- a/export/wiki/items/status.py
+++ b/export/wiki/items/status.py
@@ -5,17 +5,17 @@ from ue.properties import FloatProperty
 
 
 class StatEffectData(ExportModel):
-    value: Optional[FloatProperty] = Field(..., title="")
-    useItemQuality: bool = Field(False, title="")
-    descriptionIndex: Optional[int] = Field(..., title="")
+    value: FloatProperty = Field(..., title="Stat value to gain")
+    useItemQuality: bool = Field(False, title="Whether item quality is used")
+    descriptionIndex: int = Field(..., title="")
     pctOf: Optional[str] = Field(None, title="")
     pctAbsRange: Optional[Tuple[FloatProperty, FloatProperty]] = Field(None, title="")
     setValue: bool = Field(False, title="")
     setAddValue: bool = Field(False, title="")
-    forceUseOnDino: bool = Field(False, title="")
-    allowWhenFull: bool = Field(True, title="")
-    qualityMult: float = Field(1.0, title="")
-    duration: Optional[Union[float, FloatProperty]] = Field(0, title="")
+    forceUseOnDino: bool = Field(False, title="Whether can be used on dinos")
+    allowWhenFull: bool = Field(True, title="Whether allowed when stat is full")
+    qualityMult: float = Field(1.0, title="Item quality effect (addition)")
+    duration: Union[float, FloatProperty] = Field(0, title="Effect duration")
 
 
 def convert_status_effect(entry) -> Tuple[str, StatEffectData]:

--- a/export/wiki/stage_items.py
+++ b/export/wiki/stage_items.py
@@ -11,7 +11,7 @@ from utils.log import get_logger
 from .flags import gather_flags
 from .items.cooking import CookingIngredientData, convert_cooking_values
 from .items.crafting import CraftingData, RepairData, convert_crafting_values
-from .items.durability import DurabilityData
+from .items.durability import convert_durability_values
 from .items.egg import EggData, convert_egg_values
 from .items.status import StatEffectData, convert_status_effect
 
@@ -51,7 +51,7 @@ class Item(ExportModel):
     stackSize: Optional[IntProperty] = Field(None, title="Stack size")
     spoilsIn: Optional[FloatProperty] = Field(None, title="Spoilage time")
     spoilsTo: Optional[str] = Field(None, title="Item produced when spoiled")
-    durability: Optional[DurabilityData]
+    durability: Optional[float] = Field(None, title="Durability units (at 100% quality)")
     crafting: Optional[CraftingData]
     repair: Optional[RepairData]
     structure: Optional[str] = Field(
@@ -131,12 +131,10 @@ class ItemsStage(JsonHierarchyExportStage):
                 out.spoilsTo = _safe_get_bp_from_object(item.get('SpoilingItem', fallback=None))
 
             # Export durability info if the mechanic is enabled
-            # BROKEN, requires struct property gathering
-            # if bool(item.bUseItemDurability[0]):
-            #    out.durability = convert_durability_values(item)
+            out.durability = convert_durability_values(item)
 
             # Export crafting info
-            out.crafting, out.repair = convert_crafting_values(item)
+            out.crafting, out.repair = convert_crafting_values(item, has_durability=out.durability is not None)
 
             # Export string references to the structure or weapon templates (if any), which can then be looked up in
             # a separate file, without having this export grow in size too much.

--- a/export/wiki/stage_items.py
+++ b/export/wiki/stage_items.py
@@ -32,37 +32,28 @@ class Item(ExportModel):
     description: Optional[str] = None
     bp: str = Field(..., title="Blueprint path")
     parent: Optional[str] = Field(None, description="Full path to the parent class of this item")
-    icon: Optional[str] = Field(
-        None,
-        title="Icon blueprint path",
-        description="This is either a texture or a material instance",
-    )
+    icon: Optional[str] = Field(None, description="Blueprint path pointing to either a texture or material instance.")
     type: Optional[str] = None
-    flags: Optional[List[str]] = Field(
-        list(),
-        description="Relevant boolean flags that are True for this item",
-    )
+    flags: Optional[List[str]] = Field(list(), description="Relevant boolean flags that are True for this item")
     folders: List[str] = Field(
         [],
         title="Crafting station folder",
         description="These are the folders in a crafting station where this item's blueprint is shown.",
     )
-    weight: Optional[FloatProperty] = Field(None, title="Weight of a single unit")
+    weight: Optional[FloatProperty] = Field(None, description="Weight of a single item")
     stackSize: Optional[IntProperty] = None
-    spoilsIn: Optional[FloatProperty] = Field(None, title="Spoilage time")
-    spoilsTo: Optional[str] = Field(None, title="Spoilage product")
-    durability: Optional[float] = Field(None, title="Durability units", description="At 100% quality")
+    spoilsIn: Optional[FloatProperty] = Field(None, description="Spoilage time in seconds")
+    spoilsTo: Optional[str] = Field(None, description="Blueprint path of the spoilage product")
+    durability: Optional[float] = Field(None, description="Durability at 100% quality")
     crafting: Optional[CraftingData]
     repair: Optional[RepairData]
     structure: Optional[str] = Field(
         None,
-        title="Structure blueprint path",
-        description="Can be looked up in structures.json.",
+        description="Blueprint path of the structure created by this item (can by looked up in structures.json).",
     )
     weapon: Optional[str] = Field(
         None,
-        title="Weapon blueprint path",
-        description="Can be looked up in weapons.json.",
+        description="Blueprint path of the weapon created by this item (can by looked up in weapons.json).",
     )
     statEffects: Optional[Dict[str, StatEffectData]] = Field(None, description="Stat changes caused by consumption of the item")
     egg: Optional[EggData]

--- a/export/wiki/stage_items.py
+++ b/export/wiki/stage_items.py
@@ -13,7 +13,7 @@ from .items.cooking import CookingIngredientData, convert_cooking_values
 from .items.crafting import CraftingData, RepairData, convert_crafting_values
 from .items.durability import convert_durability_values
 from .items.egg import EggData, convert_egg_values
-from .items.status import StatEffectData, convert_status_effect
+from .items.status import StatEffectData, convert_status_effects
 
 __all__ = [
     'ItemsStage',
@@ -28,16 +28,16 @@ OUTPUT_FLAGS = (
 
 
 class Item(ExportModel):
-    name: Optional[str] = Field(..., title="Descriptive name")
-    description: Optional[str] = Field(None, title="Description of the item")
-    bp: str = Field(..., title="Full blueprint path")
-    parent: Optional[str] = Field(None, title="Full path to the parent class of this item")
+    name: Optional[str]
+    description: Optional[str] = None
+    bp: str = Field(..., title="Blueprint path")
+    parent: Optional[str] = Field(None, description="Full path to the parent class of this item")
     icon: Optional[str] = Field(
         None,
-        title="Full blueprint path to the icon",
+        title="Icon blueprint path",
         description="This is either a texture or a material instance",
     )
-    type: Optional[str] = Field(None, description="")
+    type: Optional[str] = None
     flags: Optional[List[str]] = Field(
         list(),
         description="Relevant boolean flags that are True for this item",
@@ -45,13 +45,13 @@ class Item(ExportModel):
     folders: List[str] = Field(
         [],
         title="Crafting station folder",
-        description="This is the folder in a crafting station where this item's blueprint is shown.",
+        description="These are the folders in a crafting station where this item's blueprint is shown.",
     )
     weight: Optional[FloatProperty] = Field(None, title="Weight of a single unit")
-    stackSize: Optional[IntProperty] = Field(None, title="Stack size")
+    stackSize: Optional[IntProperty] = None
     spoilsIn: Optional[FloatProperty] = Field(None, title="Spoilage time")
-    spoilsTo: Optional[str] = Field(None, title="Item produced when spoiled")
-    durability: Optional[float] = Field(None, title="Durability units (at 100% quality)")
+    spoilsTo: Optional[str] = Field(None, title="Spoilage product")
+    durability: Optional[float] = Field(None, title="Durability units", description="At 100% quality")
     crafting: Optional[CraftingData]
     repair: Optional[RepairData]
     structure: Optional[str] = Field(
@@ -64,7 +64,7 @@ class Item(ExportModel):
         title="Weapon blueprint path",
         description="Can be looked up in weapons.json.",
     )
-    statEffects: Optional[Dict[str, StatEffectData]] = Field(None, title="Stat effects when consumed")
+    statEffects: Optional[Dict[str, StatEffectData]] = Field(None, description="Stat changes caused by consumption of the item")
     egg: Optional[EggData]
     cooking: Optional[CookingIngredientData]
 
@@ -145,8 +145,7 @@ class ItemsStage(JsonHierarchyExportStage):
 
             # Export status effect info when item is consumed
             if item.has_override('UseItemAddCharacterStatusValues'):
-                status_effects = item.UseItemAddCharacterStatusValues[0]
-                out.statEffects = dict(convert_status_effect(entry) for entry in status_effects.values)
+                out.statEffects = convert_status_effects(item)
 
             # Export egg info
             if item.bIsEgg[0]:

--- a/export/wiki/stage_items.py
+++ b/export/wiki/stage_items.py
@@ -215,19 +215,3 @@ def _safe_get_bp_from_object(obj: Optional[ObjectProperty]) -> Optional[str]:
     if not obj or not obj.value or not obj.value.value:
         return None
     return obj.value.value.fullname
-
-
-def get_item_name(item: PrimalItem) -> Optional[str]:
-    item_name = item.get('DescriptiveNameBase', fallback=None)
-    if not item_name:
-        return None
-
-    out = str(item_name)
-
-    # The game adds the Skin suffix to the item's name if bIsItemSkin is true. This only, however, happens when the
-    # item does not generate its name at runtime through scripts - where it's probably safer for us to export the
-    # CDO name.
-    if item.bIsItemSkin[0] and not item.bUseBPGetItemName[0]:
-        out += ' Skin'
-
-    return out

--- a/export/wiki/stage_items.py
+++ b/export/wiki/stage_items.py
@@ -55,7 +55,7 @@ class Item(ExportModel):
         None,
         description="Blueprint path of the weapon created by this item (can by looked up in weapons.json).",
     )
-    statEffects: Optional[Dict[str, StatEffectData]] = Field(None, description="Stat changes caused by consumption of the item")
+    statEffects: Optional[List[StatEffectData]] = Field(None, description="Stat changes caused by consumption of the item")
     egg: Optional[EggData]
     cooking: Optional[CookingIngredientData]
 


### PR DESCRIPTION
- Append "Skin" to the name if IsItemSkin is true and name is not generated by BPs.
- Get durability from ItemStatInfos. This requires us to walk over all the parent classes, access their properties, and retrieve their fields.
- Format version bump.
- Add a parent class field.
- Always include Spoiling Product even if it's null to be more human-friendly.
- Only output crafting info if the item has a recipe.
- Skip null ingredients.
- Only output repair info if the item uses durability.
- Do not output egg colorization info. It has been too much of a mess and a more generic way of exporting material instance parameters is required.
- Export cooking water gain.
- ue: Have gather_properties(UAsset) get the default class instead of export
- ueexport: Export PrimalItems to Oviraptor tasks.