### PR TITLE
Add a tameability flag to wiki.species

### DIFF
--- a/ark/overrides.py
+++ b/ark/overrides.py
@@ -117,7 +117,7 @@ class OverrideSettings(BaseModel):
     )
     is_tameable: Optional[bool] = Field(
         None,
-        description="If true, wiki.species will be forced to emit a tameable flag.",
+        description="If not null, overrides whether wiki.species emits a tameable flag for the species.",
     )
 
     # Maps

--- a/ark/overrides.py
+++ b/ark/overrides.py
@@ -115,6 +115,10 @@ class OverrideSettings(BaseModel):
         dict(),
         description="Mapping from old to new species blueprint paths",
     )
+    is_tameable: Optional[bool] = Field(
+        None,
+        description="If true, wiki.species will be forced to emit a tameable flag.",
+    )
 
     # Maps
     svgs: MapBoundariesSettings = Field(

--- a/config/overrides.yaml
+++ b/config/overrides.yaml
@@ -1373,6 +1373,13 @@ species:
             CrystalIsles: true
             Mega: true
 
+    # Tameability overrides for wiki.species
+    /Game/Aberration/Dinos/Nameless/Xenomorph_Character_BP:
+        is_tameable: false
+
+    /Game/Aberration/Dinos/Nameless/Xenomorph_Character_BP_Male:
+        is_tameable: false
+
 
 
     # Mod-specific overrides

--- a/export/wiki/stage_species.py
+++ b/export/wiki/stage_species.py
@@ -132,11 +132,15 @@ def should_skip_from_variants(variants: Set[str], overrides: OverrideSettings) -
     return bool(variants & skip_variants)
 
 
-def is_creature_tameable(species: PrimalDinoCharacter, overrides: OverrideSettings) -> bool:
-    if overrides.is_tameable != None:
+def is_creature_tameable(species: PrimalDinoCharacter, variants: List[str], overrides: OverrideSettings) -> bool:
+    if overrides.is_tameable is not None:
         return overrides.is_tameable
 
-    if not bool(species.bCanBeTamed[0]):
+    if not species.bCanBeTamed[0]:
+        return False
+
+    # Taming is forcefully disabled on these dinos by the mission controller.
+    if 'Mission' in variants or 'VR' in variants:
         return False
 
     violent = species.bCanBeTorpid[0] and not species.bPreventSleepingTame[0]
@@ -198,7 +202,7 @@ class SpeciesStage(JsonHierarchyExportStage):
             out.variants = tuple(sorted(variants))
 
         out.flags = gather_flags(species, OUTPUT_FLAGS)
-        if is_creature_tameable(species, overrides):
+        if is_creature_tameable(species, variants, overrides):
             out.flags.append('isTameable')
 
         out.levelCaps = convert_level_data(species, dcsc)

--- a/export/wiki/stage_species.py
+++ b/export/wiki/stage_species.py
@@ -132,7 +132,7 @@ def should_skip_from_variants(variants: Set[str], overrides: OverrideSettings) -
     return bool(variants & skip_variants)
 
 
-def is_creature_tameable(species: PrimalDinoCharacter, variants: List[str], overrides: OverrideSettings) -> bool:
+def is_creature_tameable(species: PrimalDinoCharacter, variants: Set[str], overrides: OverrideSettings) -> bool:
     if overrides.is_tameable is not None:
         return overrides.is_tameable
 
@@ -145,7 +145,7 @@ def is_creature_tameable(species: PrimalDinoCharacter, variants: List[str], over
 
     violent = species.bCanBeTorpid[0] and not species.bPreventSleepingTame[0]
     nonviolent = species.bSupportWakingTame[0]
-    return violent or nonviolent
+    return violent or bool(nonviolent)
 
 
 class SpeciesStage(JsonHierarchyExportStage):

--- a/export/wiki/stage_species.py
+++ b/export/wiki/stage_species.py
@@ -132,6 +132,18 @@ def should_skip_from_variants(variants: Set[str], overrides: OverrideSettings) -
     return bool(variants & skip_variants)
 
 
+def is_creature_tameable(species: PrimalDinoCharacter, overrides: OverrideSettings) -> bool:
+    if overrides.is_tameable != None:
+        return overrides.is_tameable
+
+    if not bool(species.bCanBeTamed[0]):
+        return False
+
+    violent = species.bCanBeTorpid[0] and not species.bPreventSleepingTame[0]
+    nonviolent = species.bSupportWakingTame[0]
+    return violent or nonviolent
+
+
 class SpeciesStage(JsonHierarchyExportStage):
     def get_name(self) -> str:
         return 'species'
@@ -186,6 +198,8 @@ class SpeciesStage(JsonHierarchyExportStage):
             out.variants = tuple(sorted(variants))
 
         out.flags = gather_flags(species, OUTPUT_FLAGS)
+        if is_creature_tameable(species, overrides):
+            out.flags.append('isTameable')
 
         out.levelCaps = convert_level_data(species, dcsc)
         out.cloning = gather_cloning_data(species)
@@ -199,6 +213,7 @@ class SpeciesStage(JsonHierarchyExportStage):
         out.movementW = movement.movementW
         out.movementD = movement.movementD
         out.staminaRates = movement.staminaRates
+
         out.attack = gather_attack_data(species)
 
         return out


### PR DESCRIPTION
The isTameable flag should allow for quick checks (on top of spawner overrides) to be used primarily by spawn maps generators (with no dependencies on `ue` module) and possibly editor helper tools.