### PR TITLE
Ignore any maps found directly in /Game/Maps for extra game update sanity

### DIFF
--- a/ark/overrides.py
+++ b/ark/overrides.py
@@ -132,6 +132,7 @@ class SanityCheckSettings(BaseModel):
     min_species: Dict[str, int] = dict()
     min_items: Dict[str, int] = dict()
     min_maps: Dict[str, int] = dict()
+    ignore_maps: List[str] = list()
 
 
 class OverridesFile(BaseModel):

--- a/ark/types.py
+++ b/ark/types.py
@@ -282,6 +282,7 @@ class PrimalGameData(UEProxyStructure, uetype=PGD_CLS):
 class PrimalItem(UEProxyStructure, uetype=PRIMAL_ITEM_CLS):
     # DevKit Verified
     bIsEgg = uebools(False)
+    bIsItemSkin = uebools(False)
     bSupportDragOntoOtherItem = uebools(False)
     bUseItemDurability = uebools(True)
     bOverrideRepairingRequirements = uebools(False)
@@ -289,6 +290,7 @@ class PrimalItem(UEProxyStructure, uetype=PRIMAL_ITEM_CLS):
     bPreventCheatGive = uebools(False)
     bAllowRepair = uebools(True)
     bDurabilityRequirementIgnoredInWater = uebools(False)
+    bUseBPGetItemName = uebools(False)
     BaseCraftingXP = uefloats(2.0)
     BaseRepairingXP = uefloats(2.0)
     BaseItemWeight = uefloats(0.5)

--- a/config/overrides.yaml
+++ b/config/overrides.yaml
@@ -122,6 +122,12 @@ sanity_checks:
         '/Game/Mods/Ragnarok': 266 # 268 at last check
         '/Game/Mods/Valguero': 146 # 148 at last check
 
+    # Map folders that will be ignored from the extraction
+    # if any levels are found directly inside.
+    ignore_maps:
+        - '/Game/Maps'
+        - '/Game/Mods'
+
 
 # Override settings on a per-mod basis
 mods:

--- a/export/wiki/maps/discovery.py
+++ b/export/wiki/maps/discovery.py
@@ -2,7 +2,7 @@ from typing import Dict, Iterable, Iterator, List, Set
 
 import ue.hierarchy
 from ark.mod import get_core_mods
-from ark.overrides import get_overrides_for_map
+from ark.overrides import get_overrides, get_overrides_for_map
 from config import get_global_config
 from export.wiki.consts import LEVEL_SCRIPT_ACTOR_CLS, WORLD_CLS
 from ue.loader import AssetLoader
@@ -27,7 +27,14 @@ def group_levels_by_directory(assetnames: Iterable[str]) -> Dict[str, List[str]]
             levels[assetpath] = set()
         levels[assetpath].add(assetname)
 
-    return {path: list(sorted(names)) for path, names in levels.items()}
+    ignored_for_sanity = get_overrides().sanity_checks.ignore_maps
+
+    out = dict()
+    for path, names in levels.items():
+        if path not in ignored_for_sanity:
+            out[path] = list(sorted(names))
+
+    return out
 
 
 class LevelDiscoverer:

--- a/export/wiki/stage_items.py
+++ b/export/wiki/stage_items.py
@@ -138,3 +138,19 @@ def is_item_base_class(item: PrimalItem) -> bool:
     if not item_name or (not icon_texture and not icon_material):
         return True
     return False
+
+
+def get_item_name(item: PrimalItem) -> Optional[str]:
+    item_name = item.get('DescriptiveNameBase', fallback=None)
+    if not item_name:
+        return None
+
+    out = str(item_name)
+
+    # The game adds the Skin suffix to the item's name if bIsItemSkin is true. This only, however, happens when the
+    # item does not generate its name at runtime through scripts - where it's probably safer for us to export the
+    # CDO name.
+    if item.bIsItemSkin[0] and not item.bUseBPGetItemName[0]:
+        out += ' Skin'
+
+    return out


### PR DESCRIPTION
Chibi-Shadowmane server update has brought two levels that landed previously accidentally in the client:
- /Game/Maps/TestMapArea (DevKit test area)
- /Game/Maps/LandscapeMap (Epic Games 2014 landscape demo)

This change adds a sanity override that will hide certain map folders from `wiki.maps`, without relying on specific level names or scary regexes. In other words, it fixes a WTFWC that I have already reported back in February.

Once merged into live, the bad data should be disposed of:
```
rm -r output/data/wiki/Maps
```