### PR TITLE
Export wild level range weight tables from species. Clean up XP output.

### DIFF
--- a/ark/types.py
+++ b/ark/types.py
@@ -268,7 +268,7 @@ class PrimalDinoCharacter(UEProxyStructure, uetype=PDC_CLS):
     OverrideDinoMaxExperiencePoints = uefloats(0)
     DestroyTamesOverLevelClampOffset = ueints(0)
     bUseFixedSpawnLevel = uebools(False)
-    AbsoluteBaseLevel = ueints(-1)
+    AbsoluteBaseLevel = ueints(0)
     FinalNPCLevelMultiplier = uefloats(1.0)
     DinoBaseLevelWeightEntries: Mapping[int, ArrayProperty]  # = []
 

--- a/ark/types.py
+++ b/ark/types.py
@@ -267,6 +267,10 @@ class PrimalDinoCharacter(UEProxyStructure, uetype=PDC_CLS):
     # Experience
     OverrideDinoMaxExperiencePoints = uefloats(0)
     DestroyTamesOverLevelClampOffset = ueints(0)
+    bUseFixedSpawnLevel = uebools(False)
+    AbsoluteBaseLevel = ueints(-1)
+    FinalNPCLevelMultiplier = uefloats(1.0)
+    DinoBaseLevelWeightEntries: Mapping[int, ArrayProperty]  # = []
 
     # Death Loot
     DeathGivesDossierIndex = ueints(-1)

--- a/automate/jsonutils.py
+++ b/automate/jsonutils.py
@@ -131,6 +131,7 @@ JOIN_LINE_FIELDS = (
     'base|crouch|sprint',
     'min|max',
     'min|max|pow',
+    'chance|min|max',
     'qty|type',
     'exact|qty|type',
     'stat|value|useItemQuality',

--- a/export/wiki/models.py
+++ b/export/wiki/models.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple, Union
 
 from automate.hierarchy_exporter import ExportModel, Field
-from ue.properties import FloatProperty, IntProperty
+from ue.properties import BoolProperty, FloatProperty, IntProperty
 
 __all__ = [
     'MinMaxRange',
@@ -10,6 +10,7 @@ __all__ = [
     'ItemChancePair',
 ]
 
+BoolLike = Union[BoolProperty, bool]
 IntLike = Union[IntProperty, int]
 FloatLike = Union[FloatProperty, IntProperty, float, int]
 

--- a/export/wiki/models.py
+++ b/export/wiki/models.py
@@ -10,6 +10,7 @@ __all__ = [
     'ItemChancePair',
 ]
 
+IntLike = Union[IntProperty, int]
 FloatLike = Union[FloatProperty, IntProperty, float, int]
 
 
@@ -32,6 +33,12 @@ class WeighedClassSwap(ExportModel):
 
 
 class MinMaxRange(ExportModel):
+    min: FloatLike
+    max: FloatLike
+
+
+class MinMaxChanceRange(ExportModel):
+    chance: float
     min: FloatLike
     max: FloatLike
 

--- a/export/wiki/species/xp.py
+++ b/export/wiki/species/xp.py
@@ -119,7 +119,10 @@ def convert_level_data(species: PrimalDinoCharacter, dcsc: DinoCharacterStatusCo
             # Pack gathered data into MinMaxChanceRanges with calculated chances. The properties cannot be modified through INI
             # configs.
             for weight, min_lvl, max_lvl in entries:
-                out_level_table.append(MinMaxChanceRange(chance=clean_float(weight / weight_sum), min=min_lvl, max=max_lvl))
+                out_level_table.append(
+                    MinMaxChanceRange(chance=clean_float(weight / weight_sum),
+                                      min=clean_float(min_lvl),
+                                      max=clean_float(max_lvl)))
 
         result.wildLevelTable = out_level_table
 

--- a/export/wiki/stage_species.py
+++ b/export/wiki/stage_species.py
@@ -107,7 +107,7 @@ class Species(ExportModel):
         description="Relevant boolean flags that are True for this species",
     )
 
-    levelCaps: Optional[LevelData]
+    leveling: LevelData = LevelData()
     cloning: Optional[CloningData] = Field(
         None,
         description="Full cost is determined by Ceil(costBase + costLevel x CharacterLevel). " +
@@ -158,7 +158,7 @@ class SpeciesStage(JsonHierarchyExportStage):
         return bool(self.manager.config.export_wiki.PrettyJson)
 
     def get_format_version(self):
-        return "2"
+        return "3"
 
     def get_ue_type(self):
         return PrimalDinoCharacter.get_ue_type()
@@ -207,7 +207,8 @@ class SpeciesStage(JsonHierarchyExportStage):
         if is_creature_tameable(species, variants, overrides):
             out.flags.append('isTameable')
 
-        out.levelCaps = convert_level_data(species, dcsc)
+        if not species.bIsBossDino[0]:
+            out.leveling = convert_level_data(species, dcsc)
         out.cloning = gather_cloning_data(species)
 
         out.falling = FallingData(


### PR DESCRIPTION
- Bumped format version to 3.
- Default, common values are culled by Pydantic on maxTameLevels fields and officialCap.
- Renamed maxLevels and capOffset to sound less confusing.
- Forced spawn levels and level range weighing tables are now exported.