### PR TITLE
Parse instanced static meshes' data to retrieve instances

### DIFF
--- a/export/wiki/maps/gathering_basic.py
+++ b/export/wiki/maps/gathering_basic.py
@@ -67,7 +67,7 @@ class BaseActorListExport(MapGathererBase):
         actors: CustomActorList = cast(CustomActorList, proxy)
 
         if 'ActorList' not in actors:
-            return
+            return None
 
         for entry in actors.ActorList[0].values:
             if not entry.value.value:

--- a/export/wiki/maps/resources.py
+++ b/export/wiki/maps/resources.py
@@ -1,0 +1,105 @@
+from typing import Dict, List, Tuple
+
+from ue.asset import ExportTableItem
+from utils.log import get_logger
+
+logger = get_logger(__name__)
+
+# Mapping of known harvesting components' names to wiki's internal marker types.
+# If a name is not mapped at all, or is mapped to a None, all nodes this component is attached to will be skipped.
+#
+# Full list of all marker types: https://ark.fandom.com/wiki/Template:ResourceMap
+HARVEST_COMPONENT_MAPPING = {
+    # Metal
+    'MetalHarvestComponent_C': 'metal',
+    'MetalHarvestComponent_Rich_C': 'metal-rich',
+    'RAG_UnderwaterMetalHarvestComponent_C': 'metal-underwater',
+    # Oil
+    'OilHarvestComponent_C': 'oil-rock',
+    'OilHarvestComponentRich_C': 'oil-rock',
+    'OilHarvestComponentUnderwater_C': 'oil-rock',
+    'OilSplatterHarvest_C': 'oil-rock',
+    # Obsidian
+    'ObsidianHarvestComponent_C': 'obsidian',
+    'MountainObsidianHarvestComponent_C': 'obsidian',
+    # Crystal
+    'CrystalHarvestComponent_C': 'crystal',
+    'CrystalBushHarvestComponent_C': 'crystal',
+    'CrystalHarvestComponent_Summit_C': 'crystal',
+    'CrystalHarvestComponent_UnderwaterCave_C': 'crystal',
+    'CrystalPickupHarvestComponent_C': 'crystal',
+    # Gems
+    'GemFertileHarvestComponent_C': 'gem-green',
+    'GemFertileHarvestComponent_Light_C': 'gem-green',
+    'EX_GemFertileHarvestComponent_Light_C': 'gem-green',
+    'GemBioLumHarvestComponent_C': 'gem-blue',
+    'GemElementHarvestComponent_C': 'gem-red',
+    'GemDrakeTrenchHarvestComponent_Light_C': 'gem-red',
+    # Salt
+    'RawSaltHarvestComponent_C': 'salt',
+    'StoneHarvestComponent_Salt_C': 'salt',
+    # Sulfur
+    'SulfurHarvestComponent_C': 'sulfur',
+    'EX_SulfurHarvestComponent_C': 'sulfur',
+    # Element
+    'ElementOreHarvestComponent_C': 'element-ore',
+    'ElementShardHarvestComponent_C': 'element-shard',
+    'CityPropHarvestComponent_C': 'dust-rich',
+    'CityPropHarvestComponent_Light_C': 'dust-rich',
+    'CityPropHarvestComponent_NoLight_C': 'dust-rich',
+    # Pearls
+    'SiliconHarvestComponent_C': 'silica',
+    'SiliconHarvestComponent_gen_C': 'silica',
+    'BlackPearlHarvestComponent_C': 'black-pearl',
+    'BlackPearlHarvest_C': 'black-pearl',
+    # Keratin
+    'BoneHarvestComponent_C': 'keratin',
+    'BonesHarvestComponent_C': 'keratin',
+    # Cactus
+    'CactusHarvestComponent_C': 'cactus',
+    'CactusHarvestComponent_GEN_C': 'cactus',
+    'CactusHarvestComponent_Ex_Base_C': 'cactus',
+    'CactusHarvestComponent_Ex_Large_C': 'cactus',
+    'CactusLargeHarvestComponent_C': 'cactus',
+    'CactusManyBerriesWithPlantYHarvestComponent_C': 'cactus',
+    'CactusManyBerriesHarvestComponent_C': 'cactus',
+    'CactusFewBerriesHarvestComponent_C': 'cactus',
+    'CactusFewBerriesHarvestComponent_Ex_C': 'cactus',
+    'CactusManyBerriesWithPlantYHarvestComponent_C': 'cactus',
+    # Plants & Crops
+    'RareFlowerHarvestComponent_C': 'rare-flower',
+    'RareFlowerHarvestComponent_Jackson_C': 'rare-flower',
+    'Carrot_Pickup_C': 'rockarrot',
+    'Potatoe_Pickup_C': 'savoroot',
+}
+
+ResourceNodesByType = Dict[str, List[Tuple[float, float, float, bool]]]
+
+# TODO: Move to overrides.yaml
+CAVE_LEVEL_IDENTIFIERS = (
+    'Cave',
+    'Dungeon',
+)
+
+
+def collect_harvestable_resources(export: ExportTableItem, out: ResourceNodesByType):
+    assert export.properties
+    assert export.extended_data
+
+    # Retrieve the harvesting component class and check if it's valid.
+    component = export.properties.get_property('AttachedComponentClass', fallback=None)
+    if not component or not component.value or not component.value.value:
+        return
+
+    # Get a resource type identifier if one is available. Skip otherwise.
+    component_name = str(component.value.value.name)
+    resource_type = HARVEST_COMPONENT_MAPPING.get(component_name, None)
+    if not resource_type:
+        return
+
+    # Naively determine if the level might be related to a cave.
+    is_likely_cave = any(ident in export.asset.assetname for ident in CAVE_LEVEL_IDENTIFIERS)
+
+    # Copy visible instances from export's extended data into the world.
+    for x, y, z in export.extended_data.visible_instances:
+        out[resource_type].append((x, y, z, is_likely_cave))

--- a/export/wiki/maps/resources.py
+++ b/export/wiki/maps/resources.py
@@ -40,6 +40,7 @@ HARVEST_COMPONENT_MAPPING = {
     'EX_GemFertileHarvestComponent_Light_C': 'gem-green',
     'GemGreenHarvestComponent_C': 'gem-green',
     'GemBioLumHarvestComponent_C': 'gem-blue',
+    'GemBioLumHarvestComponent_Light_C': 'gem-blue',
     'GemBlueHarvestComponent_C': 'gem-blue',
     'GemElementHarvestComponent_C': 'gem-red',
     'GemDrakeTrenchHarvestComponent_Light_C': 'gem-red',
@@ -87,6 +88,9 @@ HARVEST_COMPONENT_MAPPING = {
     'AmbergrisHarvestComponent_C': 'ambergris',
     # Mutagel
     'MutagelHarvestComponent_C': 'mutagel',
+    # Fjordur
+    'Fjo_CrystalHarvestComponent_C': 'crystal',
+    'SeaSaltHarvestComponent_C': 'salt',
 }
 
 LEVEL_NAME_EXTRA_SUFFIX = {
@@ -140,6 +144,7 @@ def collect_harvestable_resources(export: ExportTableItem, out: ResourceNodesByT
     component_name = str(component.value.value.name)
     resource_type = HARVEST_COMPONENT_MAPPING.get(component_name, None)
     if not resource_type:
+        logger.debug(f'Resource type unknown: {component_name}')
         return
 
     # Add a suffix to the resource type depending on level (Genesis 2 rotations)

--- a/export/wiki/maps/resources.py
+++ b/export/wiki/maps/resources.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Tuple
 
 from ue.asset import ExportTableItem
+from ue.utils import get_leaf_from_assetname
 from utils.log import get_logger
 
 logger = get_logger(__name__)
@@ -9,41 +10,51 @@ logger = get_logger(__name__)
 # If a name is not mapped at all, or is mapped to a None, all nodes this component is attached to will be skipped.
 #
 # Full list of all marker types: https://ark.fandom.com/wiki/Template:ResourceMap
+# TODO: overrides.yaml
 HARVEST_COMPONENT_MAPPING = {
     # Metal
     'MetalHarvestComponent_C': 'metal',
     'MetalHarvestComponent_Rich_C': 'metal-rich',
+    'SpaceMetalHarvestComponent_Rich_C': 'metal-rich',
     'RAG_UnderwaterMetalHarvestComponent_C': 'metal-underwater',
     # Oil
     'OilHarvestComponent_C': 'oil-rock',
     'OilHarvestComponentRich_C': 'oil-rock',
     'OilHarvestComponentUnderwater_C': 'oil-rock',
     'OilSplatterHarvest_C': 'oil-rock',
+    'SpaceOilHarvestComponent_C': 'oil-rock',
     # Obsidian
     'ObsidianHarvestComponent_C': 'obsidian',
     'MountainObsidianHarvestComponent_C': 'obsidian',
+    'SpaceObsidianHarvestComponent_C': 'obsidian',
     # Crystal
     'CrystalHarvestComponent_C': 'crystal',
     'CrystalBushHarvestComponent_C': 'crystal',
     'CrystalHarvestComponent_Summit_C': 'crystal',
     'CrystalHarvestComponent_UnderwaterCave_C': 'crystal',
     'CrystalPickupHarvestComponent_C': 'crystal',
+    'CrystalHarvestComponent_HIGH_C': 'crystal-rich',
     # Gems
     'GemFertileHarvestComponent_C': 'gem-green',
     'GemFertileHarvestComponent_Light_C': 'gem-green',
     'EX_GemFertileHarvestComponent_Light_C': 'gem-green',
+    'GemGreenHarvestComponent_C': 'gem-green',
     'GemBioLumHarvestComponent_C': 'gem-blue',
+    'GemBlueHarvestComponent_C': 'gem-blue',
     'GemElementHarvestComponent_C': 'gem-red',
     'GemDrakeTrenchHarvestComponent_Light_C': 'gem-red',
+    'GemRedHarvestComponent_C': 'gem-red',
     # Salt
     'RawSaltHarvestComponent_C': 'salt',
     'StoneHarvestComponent_Salt_C': 'salt',
     # Sulfur
     'SulfurHarvestComponent_C': 'sulfur',
     'EX_SulfurHarvestComponent_C': 'sulfur',
+    'SulfurHarvestComponent_C': 'sulfur',
     # Element
     'ElementOreHarvestComponent_C': 'element-ore',
     'ElementShardHarvestComponent_C': 'element-shard',
+    'ElementDustHarvestComponent_C': 'dust-rich',
     'CityPropHarvestComponent_C': 'dust-rich',
     'CityPropHarvestComponent_Light_C': 'dust-rich',
     'CityPropHarvestComponent_NoLight_C': 'dust-rich',
@@ -66,11 +77,45 @@ HARVEST_COMPONENT_MAPPING = {
     'CactusFewBerriesHarvestComponent_C': 'cactus',
     'CactusFewBerriesHarvestComponent_Ex_C': 'cactus',
     'CactusManyBerriesWithPlantYHarvestComponent_C': 'cactus',
+    'SeedCactus_HarvestComponent_C': 'cactus',
     # Plants & Crops
     'RareFlowerHarvestComponent_C': 'rare-flower',
     'RareFlowerHarvestComponent_Jackson_C': 'rare-flower',
     'Carrot_Pickup_C': 'rockarrot',
     'Potatoe_Pickup_C': 'savoroot',
+    # Ambergris
+    'AmbergrisHarvestComponent_C': 'ambergris',
+    # Mutagel
+    'MutagelHarvestComponent_C': 'mutagel',
+}
+
+LEVEL_NAME_EXTRA_SUFFIX = {
+    # Genesis 2 asteroid fields
+    # Level names found in /Game/Genesis2/CoreBlueprints/Environment/DayCycleManager_Gen2
+    # Ambergris
+    'Space_Backdrop_Asteroids_0': ' rot0',
+    'Space_Asteroids_0_Geo': ' rot0',
+    # Crystal
+    'Space_Backdrop_Asteroids_1': ' rot1',
+    'Space_Asteroids_1_Geo': ' rot1',
+    # Sulfur
+    'Space_Backdrop_Asteroids_2': ' rot2',
+    'Space_Asteroids_2_Geo': ' rot2',
+    # Element Shard
+    'Space_Backdrop_Asteroids_3': ' rot3',
+    'Space_Asteroids_3_Geo': ' rot3',
+    # Obsidian
+    'Space_Backdrop_Asteroids_4': ' rot4',
+    'Space_Asteroids_4_Geo': ' rot4',
+    # Oil
+    'Space_Backdrop_Asteroids_5': ' rot5',
+    'Space_Asteroids_5_Geo': ' rot5',
+    # Element Dust
+    'Space_Backdrop_Asteroids_6': ' rot6',
+    'Space_Asteroids_6_Geo': ' rot6',
+    # Black Pearls
+    'Space_Backdrop_Asteroids_7': ' rot7',
+    'Space_Asteroids_7_Geo': ' rot7',
 }
 
 ResourceNodesByType = Dict[str, List[Tuple[float, float, float, bool]]]
@@ -96,6 +141,12 @@ def collect_harvestable_resources(export: ExportTableItem, out: ResourceNodesByT
     resource_type = HARVEST_COMPONENT_MAPPING.get(component_name, None)
     if not resource_type:
         return
+
+    # Add a suffix to the resource type depending on level (Genesis 2 rotations)
+    level_name = get_leaf_from_assetname(export.asset.assetname)
+    suffix = LEVEL_NAME_EXTRA_SUFFIX.get(level_name, None)
+    if suffix:
+        resource_type += suffix
 
     # Naively determine if the level might be related to a cave.
     is_likely_cave = any(ident in export.asset.assetname for ident in CAVE_LEVEL_IDENTIFIERS)

--- a/export/wiki/stage_maps.py
+++ b/export/wiki/stage_maps.py
@@ -108,22 +108,6 @@ class MapStage(ExportStage):
         # Prepare modeled data for saving
         world.convert_for_export()
 
-        # Save harvestables if any were collected
-        if world.resource_nodes:
-            output_path = (base_path / '..' / relative_path).with_suffix('.csv')
-            data = world.resource_nodes
-
-            with output_path.open('wt') as fp:
-                fp.write('ResourceType,Lat,Long,Z,Cave?\n')
-                for resource_type, nodes in data.items():
-                    for x, y, z, is_likely_cave in nodes:
-                        lat, long = get_latlong_from_location(world, x, y)
-                        lat = clean_float(lat)
-                        long = clean_float(long)
-                        z = clean_float(z)
-
-                        fp.write(f'{resource_type},{lat},{long},{z},{1 if is_likely_cave else 0}\n')
-
         # Save modeled data.
         pretty_json = self.manager.config.export_wiki.PrettyJson
         if pretty_json is None:
@@ -156,6 +140,21 @@ class MapStage(ExportStage):
 
             # Save if the data changed
             save_json_if_changed(output, (base_path / output_path), pretty_json)
+
+        # Save harvestables if any were collected
+        if world.resource_nodes:
+            output_path = (base_path / relative_path / relative_path).with_suffix('.csv')
+            data = world.resource_nodes
+
+            with output_path.open('wt') as fp:
+                fp.write('ResourceType,Lat,Long,Z,Cave?\n')
+                for resource_type, nodes in data.items():
+                    for x, y, z, is_likely_cave in nodes:
+                        lat, long = get_latlong_from_location(world, x, y)
+                        lat = clean_float(lat)
+                        long = clean_float(long)
+                        z = clean_float(z)
+                        fp.write(f'{resource_type},{lat},{long},{z},{1 if is_likely_cave else 0}\n')
 
     def _get_schema_file_path(self, file_name: str) -> PurePosixPath:
         return PurePosixPath('.schema') / f'maps_{file_name}.json'

--- a/export/wiki/types.py
+++ b/export/wiki/types.py
@@ -43,6 +43,7 @@ __all__ = [
     'MissionType_Escort',
     'MissionType_Retrieve',
     'MissionType',
+    'HierarchicalInstancedStaticMeshComponent',
 ]
 
 
@@ -540,3 +541,11 @@ class MutagenSpawnerManager(
 class Carniflora(UEProxyStructure, uetype='/Game/Genesis2/Structures/VenusFlyTrap/VenusFlyTrap_BP.VenusFlyTrap_BP_C'):
     # No properties we can assume type for.
     RootComponent: Mapping[int, ObjectProperty]  # SceneComponent
+
+
+class HierarchicalInstancedStaticMeshComponent(UEProxyStructure,
+                                               uetype='/Script/Engine.HierarchicalInstancedStaticMeshComponent'):
+    # DevKit Verified
+    AttachedComponentClass: Mapping[int, ObjectProperty]  # = None
+
+    # DevKit Unverified

--- a/interactive/resources_wikifier.py
+++ b/interactive/resources_wikifier.py
@@ -1,0 +1,44 @@
+# flake8: noqa
+
+#%% Setup
+
+from interactive_utils import *  # pylint: disable=wrong-import-order
+
+import csv
+import json
+from collections import defaultdict
+
+#%% Main
+map = 'Valguero'
+a = set()
+
+j = defaultdict(list)
+
+with open('output/data/' + map + '.csv', 'rt') as fp:
+    with open('/tmp/resources.wiki', 'wt') as fp2:
+        for line in fp.read().split('\n'):
+            line = line.strip()
+
+            if line == 'ResourceType,Lat,Long,Z,Cave?':
+                continue
+
+            if not line:
+                continue
+
+            type, lat, long, _, cave = line.split(',')
+            lat, long = (float(lat), float(long))
+            lat, long = (round(lat, 1), round(long, 1))
+            cave = True if cave == '1' else False
+
+            if cave:
+                type += ' cave'
+
+            if (lat, long, type) in a:
+                continue
+            a.add((lat, long, type))
+
+            fp2.write(f'| {lat}, {long}, {type}\n')
+            j[type].append((lat, long))
+
+with open('/tmp/resources.json', 'wt') as fp:
+    json.dump(j, fp, separators=(',', ':'))

--- a/ue/asset.py
+++ b/ue/asset.py
@@ -8,7 +8,8 @@ from utils.log import get_logger
 from .base import UEBase
 from .context import INCLUDE_METADATA, get_ctx
 from .coretypes import ChunkPtr, CompressedChunk, GenerationInfo, NameIndex, ObjectIndex, Table
-from .properties import Box, CustomVersion, EngineVersion, Guid, PropertyTable, StringProperty, AFTER_PROPERTY_TABLE_TYPES
+from .properties import Box, CustomVersion, EngineVersion, Guid, PropertyTable, StringProperty
+from .objects import AFTER_PROPERTY_TABLE_TYPES
 from .stream import MemoryStream
 from .utils import get_clean_name
 
@@ -315,8 +316,9 @@ class ExportTableItem(UEBase):
         self._newField('properties', PropertyTable(self, weakref.proxy(stream)))
         self.properties.link()
 
+        ctx = get_ctx()
         # Read data that some types have, located after the property table
-        if self.klass.value:
+        if ctx.extended_properties and self.klass.value:
             stream.offset += 4  # skip the remaining bytes of the PropertyTable marker
 
             type_cls = AFTER_PROPERTY_TABLE_TYPES.get(str(self.klass.value.name), None)

--- a/ue/context.py
+++ b/ue/context.py
@@ -37,6 +37,7 @@ class ParsingContext:
     # metadata: bool
     link: bool
     properties: bool
+    extended_properties: bool
     bulk_data: bool
     context_level: int
 
@@ -45,6 +46,7 @@ DEFAULT_CONTEXT = ParsingContext(
     # metadata=True,
     link=True,
     properties=True,
+    extended_properties=False,
     bulk_data=False,
     context_level=1,
 )
@@ -61,6 +63,7 @@ def ue_parsing_context(
         #    metadata: Optional[bool] = None,
         link: Optional[bool] = None,
         properties: Optional[bool] = None,
+        extended_properties: Optional[bool] = None,
         bulk_data: Optional[bool] = None):
     '''
     Change the current UE parsing context.
@@ -77,6 +80,8 @@ def ue_parsing_context(
         fields['link'] = link
     if properties is not None:
         fields['properties'] = properties
+    if extended_properties is not None:
+        fields['extended_properties'] = extended_properties
     if bulk_data is not None:
         fields['bulk_data'] = bulk_data
 

--- a/ue/coretypes.py
+++ b/ue/coretypes.py
@@ -16,6 +16,8 @@ __all__ = (
     'ObjectIndex',
     'GenerationInfo',
     'CompressedChunk',
+    'StripDataFlags',
+    'BulkDataHeader',
 )
 
 
@@ -208,3 +210,43 @@ class ObjectIndex(UEBase):
     #         with p.group(4, self.__class__.__name__ + '(', ')'):
     #             p.text(str(self.index) + ", ")
     #             p.pretty(self.value)
+
+
+class StripDataFlags(UEBase):
+    display_fields = ('global_flags', 'class_flags')
+
+    def _deserialise(self):
+        self._newField('global_flags', self.stream.readInt8())
+        self._newField('class_flags', self.stream.readInt8())
+
+    def __str__(self):
+        return f'StripDataFlags ({self.global_flags}, {self.class_flags})'
+
+
+class BulkDataHeader(UEBase):
+    display_fields = ()
+
+    flags: int
+    is_payload_at_the_end: bool  # 0x0001
+    is_zlib_compressed: bool  # 0x0002
+    is_unused: bool  # 0x0020
+    is_payload_inline: bool  # 0x0040
+    length: int
+    size_on_disk: int
+    offset_in_file: int
+
+    def _deserialise(self):
+        self._newField('flags', self.stream.readInt32())
+        self._newField('is_payload_at_the_end', self.flags & 0x0001 != 0)
+        self._newField('is_zlib_compressed', self.flags & 0x0002 != 0)
+        self._newField('is_unused', self.flags & 0x0020 != 0)
+        self._newField('is_payload_inline', self.flags & 0x0040 != 0)
+        self._newField('length', self.stream.readInt32())
+        self._newField('size_on_disk', self.stream.readInt32())
+        self._newField('offset_in_file', self.stream.readUInt64())
+
+        if self.is_payload_at_the_end:
+            self.offset_in_file += self.asset.bulk_data_start_offset
+
+    def __str__(self):
+        return f'{self.length} bytes @ {self.offset_in_file}'

--- a/ue/coretypes.py
+++ b/ue/coretypes.py
@@ -213,14 +213,26 @@ class ObjectIndex(UEBase):
 
 
 class StripDataFlags(UEBase):
-    display_fields = ('global_flags', 'class_flags')
+    display_fields = ('global_flags', 'custom_flags')
+
+    global_flags: int
+    custom_flags: int
 
     def _deserialise(self):
         self._newField('global_flags', self.stream.readInt8())
-        self._newField('class_flags', self.stream.readInt8())
+        self._newField('custom_flags', self.stream.readInt8())
+
+    def is_stripped_for_editor(self) -> bool:
+        return (self.global_flags & 1) != 0
+
+    def is_stripped_for_server(self) -> bool:
+        return (self.global_flags & 2) != 0
+    
+    def is_stripped_for_custom(self, flag: int) -> bool:
+        return (self.custom_flags & flag) != 0
 
     def __str__(self):
-        return f'StripDataFlags ({self.global_flags}, {self.class_flags})'
+        return f'StripDataFlags ({self.global_flags}, {self.custom_flags})'
 
 
 class BulkDataHeader(UEBase):

--- a/ue/objects.py
+++ b/ue/objects.py
@@ -1,0 +1,56 @@
+from typing import List, Optional, Tuple
+
+from utils.log import get_logger
+
+from .base import UEBase
+from .coretypes import BulkDataHeader, NameIndex, StripDataFlags, Table
+from .properties import Guid, PropertyTable, StringProperty
+
+logger = get_logger(__name__)
+
+
+class InstancedStaticMeshComponentObject(UEBase):
+
+    visible_instances: List[Tuple[float, float, float]]
+
+    def _deserialise(self, properties: PropertyTable):  # type:ignore
+        lod_count = self.stream.readUInt32()
+
+        for index in range(lod_count):
+            strip_flags = StripDataFlags(self).deserialise()
+
+            if not strip_flags.is_stripped_for_custom(1):
+                has_color_data = self.stream.readBool8()
+                if has_color_data:
+                    color_strip = StripDataFlags(self).deserialise()
+                    self.stream.offset += 4
+                    color_num = self.stream.readUInt32()
+
+                    # Required for client data to be parsed.
+                    if color_num > 0 and not color_strip.is_stripped_for_server():
+                        self.stream.offset += 4 * color_num
+
+        size = self.stream.readUInt32()
+        num_instances = self.stream.readUInt32()
+        instances = []
+
+        for index in range(num_instances):
+            # TODO: check if instance is visible
+
+            # Each instance is described as a 4x4 matrix. Last row describes the origin.
+            # Discarding scale and rotation to keep only the origin.
+            self.stream.offset += 4 * 3 * 4  # 3 rows with 4 values each 4 bytes long
+            x, y, z = (self.stream.readFloat(), self.stream.readFloat(), self.stream.readFloat())
+            # One more value that might be used as part of scaling.
+            self.stream.offset += 4
+            # These are UV biases we don't need. Removed in later engine releases.
+            self.stream.offset += 16
+
+            instances.append((x, y, z))
+
+        self._newField('visible_instances', instances)
+
+
+AFTER_PROPERTY_TABLE_TYPES = {
+    'HierarchicalInstancedStaticMeshComponent': InstancedStaticMeshComponentObject,
+}

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -13,7 +13,7 @@ from utils.log import get_logger
 
 from .base import UEBase
 from .context import INCLUDE_METADATA
-from .coretypes import NameIndex, ObjectIndex
+from .coretypes import BulkDataHeader, NameIndex, ObjectIndex, StripDataFlags, Table
 from .number import make_binary_operator, make_binary_operators, make_operator
 from .stream import MemoryStream
 from .utils import clean_double, clean_float
@@ -1211,8 +1211,6 @@ TYPE_MAP = {
     'IntPoint': IntPoint,
     # 'Transform': Transform, # no worky
 }
-
-AFTER_PROPERTY_TABLE_TYPES: Dict[str, Type] = {}
 
 
 def getPropertyType(typeName: str, throw=True):

--- a/ue/properties.py
+++ b/ue/properties.py
@@ -1212,6 +1212,8 @@ TYPE_MAP = {
     # 'Transform': Transform, # no worky
 }
 
+AFTER_PROPERTY_TABLE_TYPES: Dict[str, Type] = {}
+
 
 def getPropertyType(typeName: str, throw=True):
     result = TYPE_MAP.get(typeName, None)


### PR DESCRIPTION
Creating an MR to have reviews in one place, as this will need them, touching the `ue` module deeply.

- [x] Parse data in ISMCs located after the property table (i.e. in addition to standard UObject data)
- [x] Export the harvestables locations in wiki.maps
- - [x] Determine an output path
- [x] Add missing pieces that break parsing of client assets (likely lightmap/shadowmap references?)

*Project note description:*
* Every resource node is an instance of a static mesh. These instances are handled by Hierarchical Instanced Static Meshes, which is expands on the basic UObject's serialization code.
* To read the required data from HISMCs, we have to read data that is after the property table.
* We only need to read the ISM part.
* ISM has instance transforms we're looking for. They're represented by a 4x4 matrix.
* First resource map made with data from this branch is going live soon on wiki (Genesis Part 1 and Genesis Part 2 maps).