### PR TITLE
Export learnable engram groups in maps. Assign proper name to ARK_GEN2.

### DIFF
--- a/export/wiki/maps/gathering_complex.py
+++ b/export/wiki/maps/gathering_complex.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Iterable, Optional, Set, Type, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Set, Type, Union, cast
 
 from automate.hierarchy_exporter import ExportModel
 from export.wiki.consts import DAMAGE_TYPE_RADIATION_PKG
@@ -24,6 +24,17 @@ __all__ = (
     'COMPLEX_GATHERERS',
     'WorldSettingsExport',
 )
+
+# There's two separate engram groups for Gen1 and Gen2, but only the first one
+_ENGRAM_GROUP_FRIENDLY_NAMES = [
+    'Base Game',
+    'Scorched Earth',
+    'Tek',
+    'Unavailable',
+    'Aberration',
+    'Extinction',
+    'Genesis',
+]
 
 
 class WorldSettingsExport(MapGathererBase):
@@ -76,6 +87,7 @@ class WorldSettingsExport(MapGathererBase):
                 big=sanitise_output(settings.get('OverrideUIMapTextureFilled', 0, None)),
                 small=sanitise_output(settings.get('OverrideUIMapTextureSmall', 0, None)),
             ),
+            learnableEngrams=cls._convert_engrams_bit_mask(settings.ValidEngramGroupsBitMask[0].value),
             # Spawns
             onlyEventGlobalSwaps=bool(settings.bPreventGlobalNonEventSpawnOverrides[0]),
             randomNPCClassWeights=list(cls._convert_class_swaps(settings)),
@@ -98,6 +110,15 @@ class WorldSettingsExport(MapGathererBase):
                 out = convert_single_class_swap(struct.as_dict())
                 if out:
                     yield out
+
+    @classmethod
+    def _convert_engrams_bit_mask(cls, bitmask: int) -> List[str]:
+        out = []
+        for index, name in enumerate(_ENGRAM_GROUP_FRIENDLY_NAMES):
+            val = 1 << (index + 1)
+            if bitmask & val == val:
+                out.append(name)
+        return out
 
 
 class TradeListExport(MapGathererBase):

--- a/export/wiki/maps/gathering_complex.py
+++ b/export/wiki/maps/gathering_complex.py
@@ -113,6 +113,10 @@ class WorldSettingsExport(MapGathererBase):
 
     @classmethod
     def _convert_engrams_bit_mask(cls, bitmask: int) -> List[str]:
+        # Game treats value 0 as all groups enabled
+        if bitmask == 0:
+            return list(_ENGRAM_GROUP_FRIENDLY_NAMES)
+
         out = []
         for index, name in enumerate(_ENGRAM_GROUP_FRIENDLY_NAMES):
             val = 1 << (index + 1)

--- a/export/wiki/maps/models.py
+++ b/export/wiki/maps/models.py
@@ -114,6 +114,7 @@ class WorldSettings(ExportModel):
         ...,
         description="Preview textures of the map. Weapon refers to the map player can hold.",
     )
+    learnableEngrams: List[str] = Field([])
     # Spawn Settings
     onlyEventGlobalSwaps: bool = Field(
         False,

--- a/export/wiki/stage_engrams.py
+++ b/export/wiki/stage_engrams.py
@@ -141,11 +141,12 @@ class EngramsStage(JsonHierarchyExportStage):
 _ENGRAM_GROUP_MAP = {
     'ARK_PRIME': 'Base Game',
     'ARK_SCORCHEDEARTH': 'Scorched Earth',
-    'ARK_TEK': 'TEK',
+    'ARK_TEK': 'Tek',
     'ARK_UNLEARNED': 'Unavailable',
     'ARK_ABERRATION': 'Aberration',
     'ARK_EXTINCTION': 'Extinction',
-    'ARK_GENESIS': 'Genesis',
+    'ARK_GENESIS': 'Genesis 1',
+    'ARK_GEN2': 'Genesis 2',
 }
 
 

--- a/export/wiki/types.py
+++ b/export/wiki/types.py
@@ -57,6 +57,7 @@ class PrimalWorldSettings(UEProxyStructure, uetype='/Script/ShooterGame.PrimalWo
     bPreventGlobalNonEventSpawnOverrides = uebools(False)
 
     # DevKit Unverified
+    ValidEngramGroupsBitMask = ueints(2)
 
     OverrideWeaponMapTextureEmpty: Mapping[int, ObjectProperty]
     OverrideWeaponMapTextureFilled: Mapping[int, ObjectProperty]

--- a/export/wiki/types.py
+++ b/export/wiki/types.py
@@ -55,9 +55,9 @@ class PrimalWorldSettings(UEProxyStructure, uetype='/Script/ShooterGame.PrimalWo
     LongitudeScale = uefloats(800.0)
     OverrideDifficultyMax = uefloats(5.0)
     bPreventGlobalNonEventSpawnOverrides = uebools(False)
+    ValidEngramGroupsBitMask = ueints(2)
 
     # DevKit Unverified
-    ValidEngramGroupsBitMask = ueints(2)
 
     OverrideWeaponMapTextureEmpty: Mapping[int, ObjectProperty]
     OverrideWeaponMapTextureFilled: Mapping[int, ObjectProperty]


### PR DESCRIPTION
Changes to output:
- stage_engrams: ARK_GEN2 engram group renamed to Genesis 2 for clarity.
- stage_maps: Engram groups the survivor can learn added to the world_settings file.