### PR TITLE
Export locations of Genesis 2 exclusive features

### DIFF
--- a/config/hierarchy.yaml
+++ b/config/hierarchy.yaml
@@ -177,6 +177,7 @@
             - '/Script/ShooterGame.PrimalWeaponGrenade'
     - '/Script/ShooterGame.TargetArea'
     - '/Script/ShooterGame.TerrainActor'
+    - '/Script/ShooterGame.MissionDispatcher' # UNVERIFIED
 - '/Script/Engine.ActorComponent':
     - '/Script/ShooterGame.BeamWeaponComponent'
     - '/Script/Engine.SceneComponent':

--- a/export/wiki/maps/file_models.py
+++ b/export/wiki/maps/file_models.py
@@ -43,7 +43,7 @@ class Actors(MapExportFileModel):
     wyvernNests: List[models.WyvernNest] = []
     # Ragnarok
     iceWyvernNests: List[models.IceWyvernNest] = []
-    # Genesis Part 1
+    # Genesis: Part 1
     oilVents: List[models.OilVent] = []
     lunarOxygenVents: List[models.LunarOxygenVent] = []
     # Aberration
@@ -53,10 +53,13 @@ class Actors(MapExportFileModel):
     drakeNests: List[models.DrakeNest] = []
     # Valguero
     deinonychusNests: List[models.DeinonychusNest] = []
-    # Genesis Part 1
+    # Genesis: Part 1
     glitches: List[models.Glitch] = []
     magmasaurNests: List[models.MagmasaurNest] = []
-    poisonTrees: List[models.PoisonTree]
+    poisonTrees: List[models.PoisonTree] = []
+    # Genesis: Part 2
+    mutagenBulbs: List[models.MutagenBulb] = []
+    carniflora: List[models.Carniflora] = []
 
 
 class Missions(MapExportFileModel):

--- a/export/wiki/maps/gathering_basic.py
+++ b/export/wiki/maps/gathering_basic.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional, Set, Type, cast
 
 from automate.hierarchy_exporter import ExportModel
-from export.wiki.types import CustomActorList, GasVein, GasVeinGen1, LunarOxygenVentGen1, \
+from export.wiki.types import Carniflora, CustomActorList, GasVein, GasVeinGen1, LunarOxygenVentGen1, \
     OilVein, OilVentGen1, PlayerStart, PointOfInterestBP, PointOfInterestListGen1, PoisonTree, \
     PrimalStructurePowerNode, PrimalStructurePowerNode_Damaged, WaterVein, WildPlantSpeciesZ
 from ue.asset import ExportTableItem
@@ -229,6 +229,11 @@ class MagmasaurNests(BaseActorListExport):
     MODEL = models.MagmasaurNest
 
 
+class CarnifloraExport(BaseActorExport):
+    CLASSES = {Carniflora.get_ue_type()}
+    MODEL = models.Carniflora
+
+
 BASIC_GATHERERS = [
     # Core
     PlayerSpawnPointExport,
@@ -245,10 +250,12 @@ BASIC_GATHERERS = [
     IceWyvernNests,
     # Valguero
     DeinonychusNests,
-    # Genesis Part 1
+    # Genesis: Part 1
     GlitchExport,
     OilVentExport,
     LunarOxygenVentExport,
     MagmasaurNests,
     PoisonTreeExport,
+    # Genesis: Part 2
+    CarnifloraExport,
 ]

--- a/export/wiki/maps/gathering_complex.py
+++ b/export/wiki/maps/gathering_complex.py
@@ -5,8 +5,9 @@ from automate.hierarchy_exporter import ExportModel
 from export.wiki.consts import DAMAGE_TYPE_RADIATION_PKG
 from export.wiki.models import MinMaxRange
 from export.wiki.spawn_groups.structs import convert_single_class_swap
-from export.wiki.types import BiomeZoneVolume, DayCycleManager_Gen1, ExplorerNote, HexagonTradableOption, MissionDispatcher, \
-    MissionDispatcher_MultiUsePylon, NPCZoneManager, PrimalWorldSettings, SupplyCrateSpawningVolume, TogglePainVolume
+from export.wiki.types import BiomeZoneVolume, DayCycleManager_Gen1, ExplorerNote, HexagonTradableOption, \
+    MissionDispatcher, MissionDispatcher_FinalBattle, MissionDispatcher_MultiUsePylon, NPCZoneManager, \
+    PrimalWorldSettings, SupplyCrateSpawningVolume, TogglePainVolume
 from ue.asset import ExportTableItem
 from ue.gathering import gather_properties
 from ue.properties import ArrayProperty, ObjectProperty, StringProperty
@@ -446,11 +447,17 @@ class MissionDispatcherExport(MapGathererBase):
         location = get_actor_location_vector(dispatcher)
         out = models.MissionDispatcher(x=location.x, y=location.y, z=location.z)
 
+        # Genesis 1 has dispatchers that only allow specific missions.
         if isinstance(dispatcher, MissionDispatcher_MultiUsePylon):
             dispatcher_gen1 = cast(MissionDispatcher_MultiUsePylon, dispatcher)
             type_id = dispatcher_gen1.MissionTypeIndex[0].value
             out.type_ = cls.MISSION_TYPE_MAP.get(type_id, type_id)
             out.missions = sanitise_output(dispatcher_gen1.MissionTypes[0].values)
+
+        # Export a flag in case this dispatcher is used to start the Rockwell Prime fight.
+        # Allows for easier identification.
+        if isinstance(dispatcher, MissionDispatcher_FinalBattle):
+            out.isRockwellBattle = True
 
         return out
 

--- a/export/wiki/maps/models.py
+++ b/export/wiki/maps/models.py
@@ -220,11 +220,18 @@ class PlayerSpawn(ExportModel):
 
 
 class MissionDispatcher(ExportModel):
-    type_: Union[str, int] = Field(
+    type_: Optional[Union[str, int]] = Field(
+        None,
         alias="type",
-        description="Friendly mission type name, or internal ID if unknown.",
+        description=
+        "Friendly mission type name, or internal ID if unknown, if the dispatcher is restricted to a single type (like on "
+        "Genesis 1)",
     )
-    missions: List[ObjectPath]
+    missions: Optional[List[ObjectPath]] = Field(
+        None,
+        description=
+        "List of missions that can be activated at this dispatcher. If null, any mission can be activated (like on Genesis 2).",
+    )
 
     x: FloatProperty
     y: FloatProperty

--- a/export/wiki/maps/models.py
+++ b/export/wiki/maps/models.py
@@ -232,6 +232,10 @@ class MissionDispatcher(ExportModel):
         description=
         "List of missions that can be activated at this dispatcher. If null, any mission can be activated (like on Genesis 2).",
     )
+    isRockwellBattle: bool = Field(
+        False,
+        description="Whether the dispatcher is used to activate the Rockwell Prime boss battle of Genesis 2.",
+    )
 
     x: FloatProperty
     y: FloatProperty

--- a/export/wiki/maps/models.py
+++ b/export/wiki/maps/models.py
@@ -318,3 +318,11 @@ class MagmasaurNest(Actor):
 
 class PoisonTree(Actor):
     ...
+
+
+class MutagenBulb(Actor):
+    ...
+
+
+class Carniflora(Actor):
+    ...

--- a/export/wiki/types.py
+++ b/export/wiki/types.py
@@ -323,8 +323,12 @@ class DayCycleManager_Gen1(UEProxyStructure, uetype='/Script/ShooterGame.DayCycl
     GenesisTradableOptions: Mapping[int, ArrayProperty]
 
 
+class MissionDispatcher(UEProxyStructure, uetype='/Script/ShooterGame.MissionDispatcher'):
+    RootComponent: Mapping[int, ObjectProperty]
+
+
 class MissionDispatcher_MultiUsePylon(
-        UEProxyStructure, uetype='/Game/Genesis/Missions/MissionDispatcher_MultiUsePylon.MissionDispatcher_MultiUsePylon_C'):
+        MissionDispatcher, uetype='/Game/Genesis/Missions/MissionDispatcher_MultiUsePylon.MissionDispatcher_MultiUsePylon_C'):
     # DevKit Verified
     MissionTypeIndex = ueints(0)
 

--- a/export/wiki/types.py
+++ b/export/wiki/types.py
@@ -526,3 +526,17 @@ class TekCloningChamber(UEProxyStructure, uetype='/Game/PrimalEarth/Structures/T
     CloningTimePerElementShard = uefloats(7.0)
 
     # DevKit Unverified
+
+
+class MutagenSpawnerManager(
+        UEProxyStructure,
+        uetype='/Game/Genesis2/CoreBlueprints/Environment/Mutagen/MutagenSpawnerManager.MutagenSpawnerManager_C'):
+    # DevKit Verified
+    Spawners: Mapping[int, ArrayProperty]  # = []
+
+    # DevKit Unverified
+
+
+class Carniflora(UEProxyStructure, uetype='/Game/Genesis2/Structures/VenusFlyTrap/VenusFlyTrap_BP.VenusFlyTrap_BP_C'):
+    # No properties we can assume type for.
+    RootComponent: Mapping[int, ObjectProperty]  # SceneComponent

--- a/export/wiki/types.py
+++ b/export/wiki/types.py
@@ -338,6 +338,12 @@ class MissionDispatcher_MultiUsePylon(
     RootComponent: Mapping[int, ObjectProperty]
 
 
+class MissionDispatcher_FinalBattle(
+        MissionDispatcher,
+        uetype='/Game/Genesis2/Missions/MissionDispatcher_Gen2_FinalBattle.MissionDispatcher_Gen2_FinalBattle_C'):
+    ...
+
+
 class PlayerStart(UEProxyStructure, uetype='/Script/Engine.PlayerStart'):
     # DevKit Verified
     SpawnPointRegion = ueints(-1)


### PR DESCRIPTION
- Mission terminals
- Carnifloras
- Mutagen Bulb spawn points
- Genesis 2 also introduced a new class for the mission dispatchers, and retargetted the Gen1 MultiUse-based terminals. The class is added temporarily into hierarchy under Engine.Actor, until it can be verified in the Devkit, whenever an update comes out.