### PR TITLE
Extend wiki.species' is_tameable to override taming methods in ASB

### DIFF
--- a/ark/overrides.py
+++ b/ark/overrides.py
@@ -48,9 +48,9 @@ class ColorRegionSettings(BaseModel):
 
 
 class TamingMethod(str, Enum):
-    none = 'no'
-    knockout = 'knockout'
+    none = 'none'
     awake = 'awake'
+    knockout = 'knockout'
 
 
 class MapBoundariesSettings(BaseModel):

--- a/ark/overrides.py
+++ b/ark/overrides.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import MutableMapping as Map
 from copy import deepcopy
+from enum import Enum
 from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -44,6 +45,12 @@ class ColorRegionSettings(BaseModel):
         dict(),
         description="Override individual region names, in for dict form `region_num: \"name\"`",
     )
+
+
+class TamingMethod(str, Enum):
+    none = 'no'
+    knockout = 'knockout'
+    awake = 'awake'
 
 
 class MapBoundariesSettings(BaseModel):
@@ -119,9 +126,9 @@ class OverrideSettings(BaseModel):
         dict(),
         description="Mapping from old to new species blueprint paths",
     )
-    is_tameable: Optional[bool] = Field(
+    taming_method: Optional[TamingMethod] = Field(
         None,
-        description="If not null, overrides whether wiki.species emits a tameable flag for the species.",
+        description="Overrides the taming method of the species.",
     )
 
     # Maps

--- a/automate/config/sections.py
+++ b/automate/config/sections.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Extra
 
 from utils.name_convert import snake_to_kebab
 
-from .util_types import IniStringList, ModAliases, ModIdAccess
+from .util_types import IniStringList, ModAliases, ModIdAccess, TamingMethod
 
 
 class SettingsSection(BaseModel):

--- a/automate/config/sections.py
+++ b/automate/config/sections.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Extra
 
 from utils.name_convert import snake_to_kebab
 
-from .util_types import IniStringList, ModAliases, ModIdAccess, TamingMethod
+from .util_types import IniStringList, ModAliases, ModIdAccess
 
 
 class SettingsSection(BaseModel):

--- a/config/config.ini
+++ b/config/config.ini
@@ -102,7 +102,6 @@ CrystalIsles=CrystalIsles
 1696957410=MarniiMods: Horses
 1729386191=Additional Creatures: Bonus Content
 1734595558=Pyria: The Second Chapter  # Requires 1090809604, 1268749723 and more
-1768499278=Additional Creatures 2: JPE Rebalance
 1783616332=Ice Wyvern Mating
 1785800853=Ark Transcendence
 1787443195=The Chasm - Additional Creatures
@@ -146,6 +145,7 @@ CrystalIsles=CrystalIsles
 1268749723=Origin Manticore
 1729512589=ARK Additions: Brachiosaurus!
 1590726079=Auto-Harvest Ankylo
+1768499278=Additional Creatures 2: JPE Rebalance
 
 [optimisation]
 SearchIgnore= # List of regexes used to filter out paths when searching for species

--- a/config/overrides.yaml
+++ b/config/overrides.yaml
@@ -1410,22 +1410,22 @@ species:
 
     # Tameability overrides for wiki.species
     /Game/Aberration/Dinos/Nameless/Xenomorph_Character_BP:
-        is_tameable: false
+        taming_method: none
 
     /Game/Aberration/Dinos/Nameless/Xenomorph_Character_BP_Male:
-        is_tameable: false
+        taming_method: none
 
     /Game/Genesis/Dinos/Shapeshifter/Shapeshifter_Large/Shapeshifter_Large_Character_BP:
-        is_tameable: true
+        taming_method: none
 
     /Game/Genesis/Dinos/Shapeshifter/Shapeshifter_Small/Shapeshifter_Small_Character_BP:
-        is_tameable: true
+        taming_method: awake
 
     /Game/Genesis2/Dinos/SpaceDolphin/SpaceDolphin_Character_BP:
-        is_tameable: true
+        taming_method: awake
 
     /Game/Genesis2/Dinos/TekStrider/TekStrider_Character_BP:
-        is_tameable: true
+        taming_method: awake
 
 
 

--- a/export/asb/export_asb_values.py
+++ b/export/asb/export_asb_values.py
@@ -182,7 +182,7 @@ def values_for_species(asset: UAsset, proxy: PrimalDinoCharacter) -> Optional[Di
     if char_props.bCanBeTamed[0] or True:  # ASB currently requires all species to have taming data
         taming = None
         try:
-            taming = gather_taming_data(char_props, dcsc_props)
+            taming = gather_taming_data(char_props, dcsc_props, overrides)
         except (AssetNotFound, ModNotFound) as ex:
             logger.warning(f'Failure while gathering taming data for {asset.assetname}:\n\t{ex}')
         if taming:

--- a/export/asb/taming.py
+++ b/export/asb/taming.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+from ark.overrides import OverrideSettings, TamingMethod
 from ark.types import PrimalDinoCharacter, PrimalDinoStatusComponent
 from ue.utils import clean_double as cd
 from ue.utils import clean_float as cf
@@ -9,7 +10,9 @@ __all__ = [
 ]
 
 
-def gather_taming_data(char_props: PrimalDinoCharacter, dcsc_props: PrimalDinoStatusComponent) -> Dict[str, Any]:
+def gather_taming_data(char_props: PrimalDinoCharacter,
+                       dcsc_props: PrimalDinoStatusComponent,
+                       overrides: OverrideSettings) -> Dict[str, Any]:
     data: Dict[str, Any] = dict()
 
     # Currently unable to gather the foods list
@@ -17,10 +20,15 @@ def gather_taming_data(char_props: PrimalDinoCharacter, dcsc_props: PrimalDinoSt
     favorite_kibble: Optional[str] = None
     special_food_values: Optional[List[Dict[str, Dict[str, List[int]]]]] = None
 
-    can_tame = char_props.bCanBeTamed[0]
-    can_knockout = char_props.bCanBeTorpid[0]
-    data['nonViolent'] = char_props.bSupportWakingTame[0] and can_tame
-    data['violent'] = not char_props.bPreventSleepingTame[0] and can_tame and can_knockout
+    if overrides.taming_method:
+        can_tame = overrides.taming_method != TamingMethod.none
+        data['nonViolent'] = overrides.taming_method == TamingMethod.awake
+        data['violent'] = overrides.taming_method == TamingMethod.knockout
+    else:
+        can_tame = char_props.bCanBeTamed[0]
+        can_knockout = char_props.bCanBeTorpid[0]
+        data['nonViolent'] = char_props.bSupportWakingTame[0] and can_tame
+        data['violent'] = not char_props.bPreventSleepingTame[0] and can_tame and can_knockout
 
     if can_tame or True:
         data['tamingIneffectiveness'] = cf(char_props.TameIneffectivenessByAffinity[0].rounded_value)

--- a/export/asb/taming.py
+++ b/export/asb/taming.py
@@ -10,8 +10,7 @@ __all__ = [
 ]
 
 
-def gather_taming_data(char_props: PrimalDinoCharacter,
-                       dcsc_props: PrimalDinoStatusComponent,
+def gather_taming_data(char_props: PrimalDinoCharacter, dcsc_props: PrimalDinoStatusComponent,
                        overrides: OverrideSettings) -> Dict[str, Any]:
     data: Dict[str, Any] = dict()
 
@@ -25,7 +24,7 @@ def gather_taming_data(char_props: PrimalDinoCharacter,
         data['nonViolent'] = overrides.taming_method == TamingMethod.awake
         data['violent'] = overrides.taming_method == TamingMethod.knockout
     else:
-        can_tame = char_props.bCanBeTamed[0]
+        can_tame = bool(char_props.bCanBeTamed[0])
         can_knockout = char_props.bCanBeTorpid[0]
         data['nonViolent'] = char_props.bSupportWakingTame[0] and can_tame
         data['violent'] = not char_props.bPreventSleepingTame[0] and can_tame and can_knockout

--- a/export/wiki/stage_species.py
+++ b/export/wiki/stage_species.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional, Set, Tuple, cast
 
 from ark.gathering import gather_dcsc_properties
-from ark.overrides import OverrideSettings, get_overrides_for_species
+from ark.overrides import OverrideSettings, get_overrides_for_species, TamingMethod
 from ark.types import PrimalDinoCharacter
 from ark.variants import adjust_name_from_variants, get_variants_from_assetname, get_variants_from_species
 from automate.hierarchy_exporter import ExportFileModel, ExportModel, Field, JsonHierarchyExportStage
@@ -136,8 +136,8 @@ def should_skip_from_variants(variants: Set[str], overrides: OverrideSettings) -
 
 
 def is_creature_tameable(species: PrimalDinoCharacter, variants: Set[str], overrides: OverrideSettings) -> bool:
-    if overrides.is_tameable is not None:
-        return overrides.is_tameable
+    if overrides.taming_method:
+        return overrides.taming_method != TamingMethod.none
 
     if not species.bCanBeTamed[0]:
         return False

--- a/schema/overrides.yaml.json
+++ b/schema/overrides.yaml.json
@@ -28,7 +28,7 @@
 					"region_names": {}
 				},
 				"species_remaps": {},
-				"is_tameable": null,
+				"taming_method": null,
 				"svgs": {
 					"border_top": 7.2,
 					"border_left": 7.2,
@@ -144,6 +144,16 @@
 					}
 				}
 			}
+		},
+		"TamingMethod": {
+			"title": "TamingMethod",
+			"description": "An enumeration.",
+			"enum": [
+				"none",
+				"awake",
+				"knockout"
+			],
+			"type": "string"
 		},
 		"MapBoundariesSettings": {
 			"title": "MapBoundariesSettings",
@@ -349,10 +359,13 @@
 						"type": "string"
 					}
 				},
-				"is_tameable": {
-					"title": "Is Tameable",
-					"description": "If not null, overrides whether wiki.species emits a tameable flag for the species.",
-					"type": "boolean"
+				"taming_method": {
+					"description": "Overrides the taming method of the species.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/TamingMethod"
+						}
+					]
 				},
 				"svgs": {
 					"title": "SVGs",


### PR DESCRIPTION
This change allows overrides of taming methods in output of the ASB export, while maintaining the isTameable flag in wiki.species.

`is_tameable` (bool) is replaced with `taming_method`, whose value is either (as checked in with the Discord channel) `null` (to use the default detection as supplied by the export), `none` (to override detection and mark the creature as untameable), `knockout` (to override as a knockout/violent tame) or `awake` (to override as a "non-violent" tame that does not have to be put in sleep, like Equus, small monkeys, Noglins, Troodons, etc.)

I'm unable to currently test the changes.