### PR TITLE
Split loot handling code. Extend item set exports.

### DIFF
--- a/export/wiki/loot/gathering.py
+++ b/export/wiki/loot/gathering.py
@@ -51,15 +51,13 @@ def decode_item_entry(entry) -> ItemSetEntry:
     items_iter = (decode_item_name(item) for item in d['Items'].values)
     weights_iter = chain(d['ItemsWeights'].values, repeat(1))
 
-    print(d)
-
     return ItemSetEntry(
         name=d['ItemEntryName'] or None,
         weight=d['EntryWeight'],
         rollOneItemOnly=d.get('bApplyQuantityToSingleItem', False),  # may not be present in old mods
         qty=MinMaxPowerRange(min=d['MinQuantity'], max=d['MaxQuantity'], pow=d['QuantityPower']),
         quality=MinMaxPowerRange(min=d['MinQuality'], max=d['MaxQuality'], pow=d['QualityPower']),
-        bpChance=d['bForceBlueprint'] and 1 or d['ChanceToBeBlueprintOverride'],
+        bpChance=min(0, max(1, d['bForceBlueprint'] and 1 or d['ChanceToBeBlueprintOverride'])),
         grindable=d.get('bForcePreventGrinding', False),  # may not be present in old mods
         statMaxMult=d.get('ItemStatClampsMultiplier', 0) or 1,  # may not be present in old mods
         items=list(zip(weights_iter, items_iter)),

--- a/export/wiki/loot/gathering.py
+++ b/export/wiki/loot/gathering.py
@@ -1,0 +1,133 @@
+from itertools import chain, repeat
+from typing import Any, List, Optional
+
+from export.wiki.models import MinMaxPowerRange
+from export.wiki.types import PrimalInventoryComponent, PrimalStructureItemContainer_SupplyCrate
+from ue.hierarchy import find_parent_classes
+
+from .models import ItemSet, ItemSetEntry
+
+
+def get_loot_sets(lootinv: PrimalInventoryComponent | PrimalStructureItemContainer_SupplyCrate) -> List[Any]:
+    item_sets: List[Any] = []
+    # Add base item sets to the list
+    base_sets = lootinv.get('ItemSetsOverride', fallback=None)
+    if base_sets and base_sets.value and base_sets.value.value:
+        sets = _get_item_sets_override(base_sets)
+        item_sets.extend(sets)
+    else:
+        base_sets = lootinv.get('ItemSets', fallback=None)
+        if base_sets and base_sets.values:
+            sets = base_sets.values
+            item_sets.extend(sets)
+
+    # Add additional item sets to the list
+    extra_sets = lootinv.get('AdditionalItemSetsOverride', fallback=None)
+    if extra_sets and extra_sets.value and extra_sets.value.value:
+        sets = _get_item_sets_override(extra_sets)
+        item_sets.extend(sets)
+    else:
+        extra_sets = lootinv.get('AdditionalItemSets', fallback=None)
+        if extra_sets and extra_sets.values:
+            sets = extra_sets.values
+            item_sets.extend(sets)
+
+    return item_sets
+
+
+def decode_item_name(item):
+    item = item.value
+    if not item:
+        return None
+    item = item.value
+    if not item:
+        return None
+    return str(item.name)
+
+
+def decode_item_entry(entry) -> ItemSetEntry:
+    d = entry.as_dict()
+
+    items_iter = (decode_item_name(item) for item in d['Items'].values)
+    weights_iter = chain(d['ItemsWeights'].values, repeat(1))
+
+    print(d)
+
+    return ItemSetEntry(
+        name=d['ItemEntryName'] or None,
+        weight=d['EntryWeight'],
+        rollOneItemOnly=d.get('bApplyQuantityToSingleItem', False),  # may not be present in old mods
+        qty=MinMaxPowerRange(min=d['MinQuantity'], max=d['MaxQuantity'], pow=d['QuantityPower']),
+        quality=MinMaxPowerRange(min=d['MinQuality'], max=d['MaxQuality'], pow=d['QualityPower']),
+        bpChance=d['bForceBlueprint'] and 1 or d['ChanceToBeBlueprintOverride'],
+        grindable=d.get('bForcePreventGrinding', False),  # may not be present in old mods
+        statMaxMult=d.get('ItemStatClampsMultiplier', 0) or 1,  # may not be present in old mods
+        items=list(zip(weights_iter, items_iter)),
+    )
+
+
+def _gather_lootitemset_data(asset_ref):
+    loader = asset_ref.asset.loader
+    asset = loader.load_related(asset_ref)
+    assert asset.default_export
+    d = dict()
+
+    for node in find_parent_classes(asset.default_export):
+        if not node.startswith('/Game/'):
+            break
+
+        asset = loader[node]
+        assert asset.default_export
+
+        item_set = asset.default_export.properties.get_property('ItemSet', fallback=None)
+        if item_set:
+            set_data = item_set.as_dict()
+            for key, value in set_data.items():
+                if key not in d:
+                    d[key] = value
+
+    return d
+
+
+def _get_item_sets_override(asset_ref):
+    loader = asset_ref.asset.loader
+    asset = loader.load_related(asset_ref)
+    assert asset.default_export
+
+    for node in find_parent_classes(asset.default_export):
+        if not node.startswith('/Game/'):
+            break
+
+        asset = loader[node]
+        assert asset.default_export
+
+        sets = asset.default_export.properties.get_property('ItemSets', fallback=None)
+        if sets:
+            return sets.values
+
+    return []
+
+
+def decode_item_set(item_set, bp: Optional[str] = None) -> ItemSet:
+    if isinstance(item_set, dict):
+        d = item_set
+        override = None
+    else:
+        d = item_set.as_dict()
+        override = d['ItemSetOverride']
+
+    if override:
+        return decode_item_set(_gather_lootitemset_data(override), bp=override.value.value.fullname)
+
+    return ItemSet(
+        bp=bp,
+        name=d.get('SetName', None) or None,
+        weight=d.get('SetWeight', 1.0),
+        canRepeatItems=not d.get('bItemsRandomWithoutReplacement', False),
+        qtyScale=MinMaxPowerRange(
+            min=d.get('MinNumItems', 1.0),
+            max=d.get('MaxNumItems', 1.0),
+            pow=d.get('NumItemsPower', 1.0),
+        ),
+        entries=[decode_item_entry(entry) for entry in d['ItemEntries'].values],
+    )

--- a/export/wiki/loot/models.py
+++ b/export/wiki/loot/models.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from automate.hierarchy_exporter import ExportModel, Field
+from export.wiki.models import BoolLike, FloatLike, MinMaxPowerRange
+from ue.properties import FloatProperty, StringLikeProperty
+
+
+class ItemSetEntry(ExportModel):
+    name: Optional[StringLikeProperty]
+    weight: FloatProperty
+    rollOneItemOnly: BoolLike = False
+    qty: MinMaxPowerRange
+    quality: MinMaxPowerRange
+    bpChance: FloatLike = 0
+    grindable: BoolLike = False
+    statMaxMult: FloatLike = 1
+
+    items: list[tuple[FloatProperty | float, Optional[str]]] = Field(
+        ...,
+        description="Pairs of (weighted chance, item class name)",
+    )
+
+
+class ItemSet(ExportModel):
+    bp: Optional[str] = None
+    name: Optional[StringLikeProperty]
+    weight: FloatProperty | float
+    canRepeatItems: BoolLike = Field(
+        True,
+        description="Each item entry can be picked more than once",
+    )
+    qtyScale: MinMaxPowerRange
+    entries: list[ItemSetEntry]

--- a/export/wiki/missions/rewards.py
+++ b/export/wiki/missions/rewards.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, cast
 
-from export.wiki.stage_drops import decode_item_name, decode_item_set
+from export.wiki.loot.gathering import decode_item_name, decode_item_set
 from export.wiki.types import MissionType, MissionType_Hunt
 
 

--- a/export/wiki/models.py
+++ b/export/wiki/models.py
@@ -60,5 +60,5 @@ class DecayTime(ExportModel):
 
 
 class ItemChancePair(ExportModel):
-    chance: float = Field(..., description="Chance this item will be selected, in an inclusive range from 0 to 1.")
+    chance: float = Field(..., description="Chance this item will be selected, in an inclusive range from 0 to 1")
     item: str

--- a/export/wiki/species/death.py
+++ b/export/wiki/species/death.py
@@ -4,8 +4,8 @@ from typing import List
 from ark.types import PrimalDinoCharacter
 from automate.hierarchy_exporter import ExportModel, Field
 from export.wiki.inherited_structs import gather_inherited_struct_fields
+from export.wiki.loot.gathering import decode_item_name
 from export.wiki.models import ItemChancePair
-from export.wiki.stage_drops import decode_item_name
 from ue.properties import FloatProperty, IntProperty
 
 

--- a/export/wiki/stage_drops.py
+++ b/export/wiki/stage_drops.py
@@ -1,44 +1,20 @@
-from itertools import chain, repeat
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, List, Optional, cast
 
 from automate.hierarchy_exporter import ExportFileModel, ExportModel, Field, JsonHierarchyExportStage
-from export.wiki.types import PrimalInventoryComponent, PrimalStructureItemContainer_SupplyCrate
-from ue.hierarchy import find_parent_classes
+from export.wiki.types import PrimalInventoryComponent
 from ue.properties import BoolProperty, FloatProperty, IntProperty, StringLikeProperty
 from ue.proxy import UEProxyStructure
 from utils.log import get_logger
 
+from .loot.gathering import decode_item_set, get_loot_sets
+from .loot.models import ItemSet
 from .models import MinMaxPowerRange, MinMaxRange
 
 __all__ = [
     'DropsStage',
-    'get_loot_sets',
-    'decode_item_name',
-    'decode_item_entry',
-    'decode_item_set',
 ]
 
 logger = get_logger(__name__)
-
-
-class ItemSetEntry(ExportModel):
-    name: Optional[StringLikeProperty]
-    weight: FloatProperty
-    qty: MinMaxPowerRange
-    quality: MinMaxPowerRange
-    forceBP: BoolProperty
-    items: List[Tuple[Union[FloatProperty, float], Optional[str]]] = Field(
-        ...,
-        description="Pairs of (weighted chance, item class name)",
-    )
-
-
-class ItemSet(ExportModel):
-    name: Optional[StringLikeProperty]
-    weight: Union[FloatProperty, float]
-    qtyScale: MinMaxPowerRange
-    qualityScale: MinMaxPowerRange
-    entries: List[ItemSetEntry]
 
 
 class Drop(ExportModel):
@@ -85,7 +61,7 @@ class DropExportModel(ExportFileModel):
 class DropsStage(JsonHierarchyExportStage):
 
     def get_format_version(self) -> str:
-        return "6"
+        return "7"
 
     def get_name(self) -> str:
         return "drops"
@@ -122,134 +98,3 @@ class DropsStage(JsonHierarchyExportStage):
             return None
 
         return result
-
-
-def get_loot_sets(lootinv: Union[PrimalInventoryComponent, PrimalStructureItemContainer_SupplyCrate]) -> List[Any]:
-    item_sets: List[Any] = []
-    # Add base item sets to the list
-    base_sets = lootinv.get('ItemSetsOverride', fallback=None)
-    if base_sets and base_sets.value and base_sets.value.value:
-        sets = _get_item_sets_override(base_sets)
-        item_sets.extend(sets)
-    else:
-        base_sets = lootinv.get('ItemSets', fallback=None)
-        if base_sets and base_sets.values:
-            sets = base_sets.values
-            item_sets.extend(sets)
-
-    # Add additional item sets to the list
-    extra_sets = lootinv.get('AdditionalItemSetsOverride', fallback=None)
-    if extra_sets and extra_sets.value and extra_sets.value.value:
-        sets = _get_item_sets_override(extra_sets)
-        item_sets.extend(sets)
-    else:
-        extra_sets = lootinv.get('AdditionalItemSets', fallback=None)
-        if extra_sets and extra_sets.values:
-            sets = extra_sets.values
-            item_sets.extend(sets)
-
-    return item_sets
-
-
-def decode_item_name(item):
-    item = item.value
-    if not item:
-        return None
-    item = item.value
-    if not item:
-        return None
-    return str(item.name)
-
-
-def decode_item_entry(entry) -> ItemSetEntry:
-    d = entry.as_dict()
-
-    items_iter = (decode_item_name(item) for item in d['Items'].values)
-    weights_iter = chain(d['ItemsWeights'].values, repeat(1))
-
-    return ItemSetEntry(
-        name=d['ItemEntryName'] or None,
-        weight=d['EntryWeight'],
-        qty=dict(
-            min=d['MinQuantity'],
-            max=d['MaxQuantity'],
-            pow=d['QuantityPower'],
-        ),
-        quality=dict(
-            min=d['MinQuality'],
-            max=d['MaxQuality'],
-            pow=d['QualityPower'],
-        ),
-        forceBP=d['bForceBlueprint'],
-        items=list(zip(weights_iter, items_iter)),
-    )
-
-
-def _gather_lootitemset_data(asset_ref):
-    loader = asset_ref.asset.loader
-    asset = loader.load_related(asset_ref)
-    assert asset.default_export
-    d = dict()
-
-    for node in find_parent_classes(asset.default_export):
-        if not node.startswith('/Game/'):
-            break
-
-        asset = loader[node]
-        assert asset.default_export
-
-        item_set = asset.default_export.properties.get_property('ItemSet', fallback=None)
-        if item_set:
-            set_data = item_set.as_dict()
-            for key, value in set_data.items():
-                if key not in d:
-                    d[key] = value
-
-    return d
-
-
-def _get_item_sets_override(asset_ref):
-    loader = asset_ref.asset.loader
-    asset = loader.load_related(asset_ref)
-    assert asset.default_export
-
-    for node in find_parent_classes(asset.default_export):
-        if not node.startswith('/Game/'):
-            break
-
-        asset = loader[node]
-        assert asset.default_export
-
-        sets = asset.default_export.properties.get_property('ItemSets', fallback=None)
-        if sets:
-            return sets.values
-
-    return []
-
-
-def decode_item_set(item_set) -> ItemSet:
-    if isinstance(item_set, dict):
-        d = item_set
-        override = None
-    else:
-        d = item_set.as_dict()
-        override = d['ItemSetOverride']
-
-    if override:
-        return decode_item_set(_gather_lootitemset_data(override))
-
-    return ItemSet(
-        name=d.get('SetName', None) or None,
-        weight=d.get('SetWeight', 1.0),
-        qtyScale=MinMaxPowerRange(
-            min=d.get('MinNumItems', 1.0),
-            max=d.get('MaxNumItems', 1.0),
-            pow=d.get('NumItemsPower', 1.0),
-        ),
-        qualityScale=MinMaxPowerRange(
-            min=d.get('MinQuality', 1.0),
-            max=d.get('MaxQuality', 1.0),
-            pow=d.get('QualityPower', 1.0),
-        ),
-        entries=[decode_item_entry(entry) for entry in d['ItemEntries'].values],
-    )

--- a/export/wiki/stage_loot_crates.py
+++ b/export/wiki/stage_loot_crates.py
@@ -6,8 +6,9 @@ from ue.properties import BoolProperty
 from ue.proxy import UEProxyStructure
 from utils.log import get_logger
 
+from .loot.gathering import decode_item_set, get_loot_sets
+from .loot.models import ItemSet
 from .models import DecayTime, MinMaxPowerRange, MinMaxRange
-from .stage_drops import ItemSet, decode_item_set, get_loot_sets
 
 __all__ = [
     'LootCratesStage',
@@ -59,7 +60,7 @@ class LootCrateExportModel(ExportFileModel):
 class LootCratesStage(JsonHierarchyExportStage):
 
     def get_format_version(self) -> str:
-        return "6"
+        return "7"
 
     def get_name(self) -> str:
         return "loot_crates"

--- a/export/wiki/stage_missions.py
+++ b/export/wiki/stage_missions.py
@@ -41,7 +41,7 @@ OUTPUT_FLAGS = (
 class MissionsStage(JsonHierarchyExportStage):
 
     def get_format_version(self) -> str:
-        return "2"
+        return "3"
 
     def get_name(self):
         return 'missions'


### PR DESCRIPTION
**COMMIT MESSAGE:**

Common code is now located under `export.wiki.loot`.

Field `forceBP` renamed to `bpChance`: now a number between 0 and 1 (inclusive), with 0 being the default. `forceBP` carries as a `1` in the new field. Format version bump(!).

Removed unused `quality` field from ItemSet: was never exported from assets.

Added `canRepeatItems` to `ItemSet` model. Will address the naming inconsistency (with `noSetReplacements`) in a future commit. Another format bump, ouch! Sorry coldino!

Added fields requested by Tekcor: `rollOneItemOnly` (instead of once per quantity), `statMaxMult` (default 1, specifies how much a stat can exceed clamps on official servers or opted-in unofficial servers), `grindable` (default is false).