### PR TITLE
Add DinoTamedAdultConsumingFoodRateMultiplier to asb output

### DIFF
--- a/export/asb/taming.py
+++ b/export/asb/taming.py
@@ -48,6 +48,11 @@ def gather_taming_data(char_props: PrimalDinoCharacter, dcsc_props: PrimalDinoSt
         data['babyFoodConsumptionMult'] = cf(dcsc_props.BabyDinoConsumingFoodRateMultiplier[0].rounded_value *
                                              dcsc_props.ExtraBabyDinoConsumingFoodRateMultiplier[0].rounded_value)
 
+        adultFoodConsumptionMult = dcsc_props.DinoTamedAdultConsumingFoodRateMultiplier[0].rounded_value
+
+        if adultFoodConsumptionMult != 1:
+            data['adultFoodConsumptionMult'] = cf(adultFoodConsumptionMult)
+            
         if eats is not None:
             data['eats'] = eats
         if special_food_values is not None:


### PR DESCRIPTION
This adds `adultFoodConsumptionMult` to asb values.json files based on `DinoTamedAdultConsumingFoodRateMultiplier` from dscs.

Currently, only Giga, Carchar, Titans (Forest, Desert, ..) and Titanosaur have values defined.  The default multiplier is 1.0.
