### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Publishing live Docker image
       if: github.event_name == 'push' && github.ref == 'refs/heads/live'
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         COMMIT: ${{ github.sha }}
         BRANCH: ${{ github.repository }}@${{ github.ref_name }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore